### PR TITLE
BOSA21Q1-122: change workflow for omniauth registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ public/uploads
 .DS_Store
 .idea
 flamegraph*
-
+Procfile.dev
 
 # Rspec
 .rspec-failures

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ DECIDIM_VERSION = '0.22.0'
 
 gem 'decidim', DECIDIM_VERSION, git: 'https://github.com/decidim/decidim'
 gem 'decidim-initiatives', DECIDIM_VERSION, git: 'https://github.com/decidim/decidim'
-gem 'decidim-verifications_omniauth', git: 'https://github.com/belighted/decidim-module-verifications_omniauth', branch: DECIDIM_VERSION
+gem 'decidim-verifications_omniauth', git: 'https://github.com/belighted/decidim-module-verifications_omniauth', branch: "BOSA21Q1-122"
 gem 'decidim-initiatives_no_signature_allowed', git: 'https://github.com/belighted/decidim-module-initiatives_nosignature_allowed', branch: DECIDIM_VERSION
 gem 'decidim-suggestions', git: 'https://github.com/belighted/decidim-module-suggestions', branch: DECIDIM_VERSION
 gem 'decidim-term_customizer', git: 'https://github.com/belighted/decidim-module-term_customizer', branch: DECIDIM_VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GIT
 
 GIT
   remote: https://github.com/belighted/decidim-module-verifications_omniauth
-  revision: ab08d3770792aa9933feabc2a06cc3c3ef30d425
+  revision: c9b7136b9584acc524753a5f2b6c2800735d7887
   branch: BOSA21Q1-122
   specs:
     decidim-verifications_omniauth (0.22.0)
@@ -71,6 +71,7 @@ GIT
       omniauth-saml (~> 1.10)
       savon (~> 2.12.0)
       signer
+      valid_email2 (~> 2.1)
 
 GIT
   remote: https://github.com/decidim/decidim
@@ -660,7 +661,7 @@ GEM
       chef-utils
     mongo (2.14.0)
       bson (>= 4.8.2, < 5.0.0)
-    mongoid (7.2.1)
+    mongoid (7.2.2)
       activemodel (>= 5.1, < 6.2)
       mongo (>= 2.10.5, < 3.0.0)
     msgpack (1.3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GIT
 
 GIT
   remote: https://github.com/belighted/decidim-module-verifications_omniauth
-  revision: c9b7136b9584acc524753a5f2b6c2800735d7887
+  revision: f3bac4a0d7812082058ef992d9a8f3dcad12f022
   branch: BOSA21Q1-122
   specs:
     decidim-verifications_omniauth (0.22.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,8 +61,8 @@ GIT
 
 GIT
   remote: https://github.com/belighted/decidim-module-verifications_omniauth
-  revision: f2be9742eb133b29e69b87324129e4509debe8c9
-  branch: 0.22.0
+  revision: ab08d3770792aa9933feabc2a06cc3c3ef30d425
+  branch: BOSA21Q1-122
   specs:
     decidim-verifications_omniauth (0.22.0)
       decidim-core (= 0.22.0)
@@ -851,7 +851,7 @@ GEM
       rubocop (>= 0.68.1)
     ruby-ole (1.2.12.2)
     ruby-progressbar (1.10.1)
-    ruby-saml (1.12.0)
+    ruby-saml (1.12.2)
       nokogiri (>= 1.10.5)
       rexml
     ruby2_keywords (0.0.4)

--- a/app/views/decidim/devise/omniauth_registrations/new.html.erb
+++ b/app/views/decidim/devise/omniauth_registrations/new.html.erb
@@ -22,7 +22,7 @@
               <%== t(".registration_title") %>
             </h5>
 
-            <p>
+            <p class="text-small">
               <%= icon "info" %>
               <%== t(".registration_info", more_url: page_path("terms-and-conditions")) %>
             </p>

--- a/app/views/decidim/devise/omniauth_registrations/new.html.erb
+++ b/app/views/decidim/devise/omniauth_registrations/new.html.erb
@@ -10,10 +10,6 @@
 
   <div class="row">
     <div class="columns large-6 medium-10 medium-centered">
-      <div class="callout info">
-        <%== t(".registration_info") %>
-      </div>
-
       <div class="card">
         <div class="card__content">
           <%= decidim_form_for(@form, as: resource_name, url: omniauth_registrations_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
@@ -22,17 +18,34 @@
               <%= f.text_field :name, readonly: true %>
             </div>
 
+            <h5 class="text-center">
+              <%== t(".registration_title") %>
+            </h5>
+
+            <p>
+              <%= icon "info" %>
+              <%== t(".registration_info", more_url: page_path("terms-and-conditions")) %>
+            </p>
+
             <div class="field">
-              <%= f.text_field :nickname %>
+              <%= f.email_field :email, oncopy: "return false", onpaste: "return false" %>
             </div>
 
             <div class="field">
-              <%= f.email_field :email %>
+              <%= f.email_field :email_confirmation %>
+            </div>
+
+            <div class="field">
+              <%= f.check_box :tos_agreement, label: t(".tos_agreement", link: link_to(t(".terms"), page_path("terms-and-conditions"), rel: "noopener noreferrer", target: "_blank")) %>
             </div>
 
             <%= f.hidden_field :uid %>
             <%= f.hidden_field :provider %>
+            <% if current_user %>
+              <%= f.hidden_field :nickname, value: current_user.nickname %>
+            <% end %>
             <%= f.hidden_field :oauth_signature %>
+            <%= f.hidden_field :step, value: "step2" %>
 
             <div class="actions">
               <%= f.submit t(".complete_profile"), class: "button expanded" %>

--- a/app/views/layouts/decidim/_wrapper.html.erb
+++ b/app/views/layouts/decidim/_wrapper.html.erb
@@ -84,7 +84,7 @@ end
                         </div>
                       <% end %>
                     <% else %>
-                      <%= link_to (current_user.email.present? ? current_user.name : t("decidim.anonymous_user")), decidim.account_path %>
+                      <%= link_to (current_user.name.present? ? current_user.name : t("decidim.anonymous_user")), decidim.account_path %>
                     <% end %>
                     <ul class="menu is-dropdown-submenu js-append usermenu-off-canvas">
                       <%= render partial: "layouts/decidim/user_menu" %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,8 @@
+---
+de:
+  decidim:
+    devise:
+      omniauth_registrations:
+        new:
+          registration_title: Optionale Daten
+          registration_info:  Ihre E-Mail-Adresse wird verwendet, um Sie über Aktionen und Themen zu informieren, die Sie auf der Plattform interessieren. Nach der Registrierung erhalten Sie eine E-Mail, um Ihre E-Mail-Adresse zu bestätigen. Wenn Sie Ihre E-Mail-Adresse hier nicht eingeben und dann bestätigen, erhalten Sie anschließend keine E-Mail-Benachrichtigung. <a href="%{more_url}" target="_blank" rel="noopener noreferrer">Weitere Informationen</a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,12 +57,11 @@ en:
     devise:
       omniauth_registrations:
         new:
-          registration_info: |-
-            Registration info (this text supports <code>HTML</code>).
-            <br/><br/>
-            <small>
-              <i>Please change me with translation key <code>decidim.devise.omniauth_registrations.new.registration_info</code><i/>
-            <small/>
+          terms: Terms and conditions
+          tos_agreement: Accept our %{link}
+          registration_title: Optional data
+          registration_info:  Your email address is used to inform you of actions and subjects that interest you on the platform. After registering, an email will be sent to you to confirm your email address. If you do not fill in your email address here and then confirm it, you will not receive any email notification afterwards. <a href="%{more_url}" target="_blank" rel="noopener noreferrer">More info</a>
+
     verifications:
       authorizations:
         index:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -63,12 +63,11 @@ fr:
     devise:
       omniauth_registrations:
         new:
-          registration_info: |-
-            Texte d'information pour la création de compte qui supporte le <code>HTML</code>.
-            <br/><br/>
-            <small>
-              <i>Please change me with translation key <code>decidim.devise.omniauth_registrations.new.registration_info</code><i/>
-            <small/>
+          terms: les termes et conditions d'utilisation
+          tos_agreement: En vous inscrivant, vous acceptez %{link}
+          registration_title: Données optionnelles
+          registration_info: Votre adresse e-mail sert à vous informer des actions et sujets qui vous intéressent sur la plateforme. Après votre inscription, un e-mail vous sera envoyé pour confirmer votre adresse e-mail. Si vous ne remplissez pas votre adresse e-mail ici et ne la confirmez pas ensuite, vous ne recevrez aucune notification par e-mail par la suite. <a href="%{more_url}" target="_blank" rel="noopener noreferrer">Plus d’info</a>
+
     pages:
       terms_and_conditions:
         refuse:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -63,13 +63,11 @@ nl:
     devise:
       omniauth_registrations:
         new:
+          terms: Terms and conditions
+          tos_agreement: Accept our %{link}
           complete_profile: Complete profile
-          registration_info: |-
-            Registration info (this text supports <code>HTML</code>).
-            <br/><br/>
-            <small>
-              <i>Please change me with translation key <code>decidim.devise.omniauth_registrations.new.registration_info</code><i/>
-            <small/>
+          registration_title: Facultatieve gegevens
+          registration_info: Uw e-mailadres wordt gebruikt om u te informeren over acties en onderwerpen die u interesseren op het platform. Na registratie ontvangt u een e-mail om uw e-mailadres te bevestigen. Als u hier uw e-mailadres niet invult en vervolgens bevestigt, ontvangt u achteraf geen e-mailnotificaties. <a href="%{more_url}" target="_blank" rel="noopener noreferrer">Meer info</a>
           sign_up: Sign up
           subtitle: Subtitle
       sessions:

--- a/lib/extends/decidim-core/app/helpers/decidim/flash_messages_helper.rb
+++ b/lib/extends/decidim-core/app/helpers/decidim/flash_messages_helper.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module FlashMessagesHelperExtend
+  extend ActiveSupport::Concern
+
+  included do
+    private
+
+    # Private: Foundation alert box.
+    #
+    # Overrides the foundation alert box helper for adding accessibility tags.
+    #
+    # value - The flash message.
+    # alert_class - The foundation class of the alert message.
+    # closable - A boolean indicating whether the close icon is added.
+    #
+    # Returns a HTML string.
+    def alert_box(value, alert_class, closable)
+      options = {
+        class: "flash callout #{alert_class}",
+        role: "alert",
+        aria: { atomic: "true" }
+      }
+      options[:data] = { closable: "" } if closable
+      content_tag(:div, options) do
+        concat sanitize(value, tags: %w(strong em a), attributes: %w(href))
+        concat close_link if closable
+      end
+    end
+  end
+end
+
+FoundationRailsHelper::FlashHelper.send(:include, FlashMessagesHelperExtend)

--- a/lib/extends/decidim-core/app/models/decidim/user.rb
+++ b/lib/extends/decidim-core/app/models/decidim/user.rb
@@ -16,17 +16,6 @@ module UserExtend
 
     validate :all_roles_are_valid
 
-    def tos_accepted?
-      return true if managed
-      return true if email.blank?
-      return false if accepted_tos_version.nil?
-
-      # For some reason, if we don't use `#to_i` here we get some
-      # cases where the comparison returns false, but calling `#to_i` returns
-      # the same number :/
-      accepted_tos_version.to_i >= organization.tos_version.to_i
-    end
-
     def active_for_authentication?
       super
     end

--- a/lib/extends/decidim-core/app/models/decidim/user.rb
+++ b/lib/extends/decidim-core/app/models/decidim/user.rb
@@ -10,7 +10,7 @@ module UserExtend
     validates :name, presence: true, unless: -> { deleted? }
     validates :nickname, presence: true, unless: -> { deleted? || managed? }, length: { maximum: Decidim::User.nickname_max_length }
     validates :locale, inclusion: { in: :available_locales }, allow_blank: true
-    validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
+    validates :tos_agreement, acceptance: true, allow_nil: true, on: :create
     validates :tos_agreement, acceptance: true, if: :user_invited?
     validates :email, :nickname, uniqueness: { scope: :organization }, unless: -> { deleted? || managed? || nickname.blank? || email.blank? }
 
@@ -25,6 +25,10 @@ module UserExtend
       # cases where the comparison returns false, but calling `#to_i` returns
       # the same number :/
       accepted_tos_version.to_i >= organization.tos_version.to_i
+    end
+
+    def active_for_authentication?
+      super
     end
 
     def after_confirmation


### PR DESCRIPTION
Updated:

* disable email confirmation when email is part of the CSAM response
* don't block users to sign in when email is not set
* change omniauth registration form UI
* send email confirmation when email is confirmed