### PR TITLE
BOSA21Q1-149: change sign in workflow for csam

### DIFF
--- a/app/views/layouts/decidim/_wrapper.html.erb
+++ b/app/views/layouts/decidim/_wrapper.html.erb
@@ -104,7 +104,14 @@ end
                   <% if current_organization.sign_up_enabled? %>
                     <%= link_to t("layouts.decidim.header.sign_up"), decidim.new_user_registration_path, class: "sign-up-link" %>
                   <% end %>
-                  <%= link_to t("layouts.decidim.header.sign_in"), decidim.new_user_session_path, class: "sign-in-link" %>
+                  <% if current_organization.enabled_omniauth_providers.keys.size === 1 && current_organization.enabled_omniauth_providers[:csam] %>
+                    <%= link_to t("layouts.decidim.header.sign_in"),
+                      decidim.send('user_csam_omniauth_authorize_path'),
+                      method: :post,
+                      class: "sign-in-link" %>
+                  <% else %>
+                    <%= link_to t("layouts.decidim.header.sign_in"), decidim.new_user_session_path, class: "sign-in-link" %>
+                  <% end %>
                 </div>
               </div>
             <% end %>


### PR DESCRIPTION
Update:

* When there is only Csam as auth option then sign in will redirect to Csam auth page.