### PR TITLE
Fix Puma config

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -13,9 +13,10 @@ port ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+puma_running_env = ENV.fetch("RAILS_ENV") { "development" }
+environment puma_running_env
 
-unless Rails.env.development?
+unless puma_running_env == "development"
   # Specifies the number of `workers` to boot in clustered mode.
   # Workers are forked webserver processes. If using threads and workers together
   # the concurrency of the application would be max `threads` * `workers`.


### PR DESCRIPTION
It seems that in production, `Rails` constant is not available at this stage.