### PR TITLE
Bosa & Bosa cities: represent user > add format document BOSA21Q1-173

### DIFF
--- a/config/locales/decidim-core/en.yml
+++ b/config/locales/decidim-core/en.yml
@@ -5,6 +5,8 @@ en:
     translated: Translated
 
   decidim:
+    authorization_form:
+      document_number_help_text: Only letters and numbers are authorized. Avoid special characters and spaces. E.g. petition20210605
     authorization_modals:
       content:
         ok:

--- a/config/locales/decidim-core/es.yml
+++ b/config/locales/decidim-core/es.yml
@@ -17,6 +17,8 @@ es:
     translated: Traducido
 
   decidim:
+    authorization_form:
+      document_number_help_text: "Sólo están autorizadas las letras y los números. Evite los caracteres especiales y los espacios. Por ejemplo: petition20210605"
     accessibility:
       logo: "%{organización} logotipo oficial de la organización"
       skip_button: Saltar al contenido principal

--- a/config/locales/decidim-core/fr.yml
+++ b/config/locales/decidim-core/fr.yml
@@ -17,6 +17,8 @@ fr:
     translate: Traduire
     translated: Traduit
   decidim:
+    authorization_form:
+      document_number_help_text: "Seuls les lettres et les chiffres sont autorisés. Évitez les caractères spéciaux et les espaces. Par exemple : petition20210605"
     accessibility:
       logo: "%{organisation} logo officiel de l'organisation"
       skip_button: Passer au contenu principal

--- a/config/locales/decidim-core/nl.yml
+++ b/config/locales/decidim-core/nl.yml
@@ -16,6 +16,8 @@ nl:
     translate: Translate
     translated: Translated
   decidim:
+    authorization_form:
+      document_number_help_text: Alleen letters en cijfers zijn toegestaan. Vermijd speciale tekens en spaties. Bijv. verzoekschrift20210605
     accessibility:
       logo: "%{organization}'s official logo"
       skip_button: Skip to main content

--- a/lib/extends/decidim-core/lib/decidim/authorization_form_builder.rb
+++ b/lib/extends/decidim-core/lib/decidim/authorization_form_builder.rb
@@ -6,6 +6,21 @@ module AuthorizationFormBuilderExtend
   extend ActiveSupport::Concern
 
   included do
+
+    def all_fields
+      fields = []
+      public_attributes.map do |name, type|
+        template = @template.content_tag(:div, input_field(name, type), class: "field")
+        if name.to_sym == :document_number
+          help_text = I18n.t("decidim.authorization_form.document_number_help_text")
+          template += content_tag(:p, help_text, class: "help-text") if help_text.present?
+        end
+        fields << template
+      end
+
+      safe_join(fields)
+    end
+
     private
 
     def input_field(name, type)

--- a/lib/extends/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb
+++ b/lib/extends/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb
@@ -77,7 +77,7 @@ class DummyAuthorizationHandler < ::Decidim::AuthorizationHandler
   private
 
   def valid_document_number
-    errors.add(:document_number, :invalid) unless document_number.to_s.end_with?("X")
+    errors.add(:document_number, :invalid) unless document_number =~ /\A[a-zA-Z0-9]+\z/
   end
 
   # If you need custom authorization logic, you can implement your own action


### PR DESCRIPTION
## Description
- What?
- - Bosa & Bosa cities: represent user > add format document
- Why?
- - The format that is requested now is: any string ending by capital “X”. Can you change the format and make it either “letters or numbers all attached” please? 
- How?
- - Extend the authorization_form_builder and override the all_fields method to add a help text under the document number field. Change locales files. Change the rule for the document number with a regular expression.

## Ticket
[BOSA21Q1-173](https://belighted.atlassian.net/browse/BOSA21Q1-173?atlOrigin=eyJpIjoiNDQyYWMyZDdlMTA5NGM1ZGIwOTNjZmFlNmIyNDZjMzAiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [ ]  Dependency upgrade
- [ ]  Bug fix
- [x]  New feature
- [ ]  Breaking changes