### PR TITLE
Avoid bots to generate errors in our Appsignal / Sentry errors reports (BOSA21Q1-215)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GIT
 
 GIT
   remote: https://github.com/belighted/decidim-module-verifications_omniauth
-  revision: 24d393389588a1a382714939e01287d6643d7e1b
+  revision: 8dbbcdccc32ce2cf818160eb9667c0ded8ff5409
   branch: 0.22.0
   specs:
     decidim-verifications_omniauth (0.22.0)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,4 @@
 
 User-agent: *
 Disallow: /*/*/*/*/proposals/
+Disallow: /*.png$

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,4 @@
 User-agent: *
 Disallow: /*/*/*/*/proposals/
 Disallow: /*.png$
+Disallow: /*/*/*/*/*/*/versions/

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,4 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+
+User-agent: *
+Disallow: /*/*/*/*/proposals/

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,3 +4,5 @@ User-agent: *
 Disallow: /*/*/*/*/proposals/
 Disallow: /*.png$
 Disallow: /*/*/*/*/*/*/versions/
+Disallow: /users/auth/csam
+Disallow: /users/auth/saml


### PR DESCRIPTION
## Description
- What?
- - Avoid bots to generate errors in our Appsignal / Sentry errors reports
- Why?
- - Preventing bots from making bad requests
- How?
- - Change robot.txt file to disallow auth path and png extension and other sub folders

## Ticket
[BOSA21Q1-215](https://belighted.atlassian.net/browse/BOSA21Q1-215?atlOrigin=eyJpIjoiOTY1ZTlmOTZlM2Q5NGY2ZmE5ZjFjMzc0ZTQ1ZjcwZDkiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [ ]  Dependency upgrade
- [ ]  Bug fix
- [x]  New feature
- [ ]  Breaking changes