### PR TITLE
Migrate Sentry (BOSA21Q1-146)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ gem "puma", "~> 4.3"
 gem 'pry'
 gem 'ruby-progressbar'
 gem 'rubyzip', require: 'zip'
-gem 'sentry-raven'
 gem 'sidekiq'
 gem 'sidekiq-scheduler'
 gem 'uglifier'
@@ -35,6 +34,15 @@ gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'
 
 gem 'dotenv-rails'
+
+gem "sentry-ruby"
+
+# and the integrations you need
+gem "sentry-rails"
+gem "sentry-sidekiq"
+gem "sentry-delayed_job"
+
+gem 'delayed_job', '~> 4.1', '>= 4.1.9'
 
 group :development, :test do
   gem 'faker', '~> 1.9'

--- a/Gemfile
+++ b/Gemfile
@@ -40,9 +40,6 @@ gem "sentry-ruby"
 # and the integrations you need
 gem "sentry-rails"
 gem "sentry-sidekiq"
-gem "sentry-delayed_job"
-
-gem 'delayed_job', '~> 4.1', '>= 4.1.9'
 
 group :development, :test do
   gem 'faker', '~> 1.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -890,8 +890,18 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (3.0.0)
+    sentry-rails (4.4.0)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.4.0.pre.beta)
+    sentry-ruby (4.4.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.4.2)
+    sentry-ruby-core (4.4.2)
+      concurrent-ruby
+      faraday
+    sentry-sidekiq (4.4.0)
+      sentry-ruby-core (~> 4.4.0.pre.beta)
     seven_zip_ruby (1.3.0)
     sidekiq (6.1.2)
       connection_pool (>= 2.2.2)
@@ -1043,7 +1053,9 @@ DEPENDENCIES
   rack-mini-profiler
   ruby-progressbar
   rubyzip
-  sentry-raven
+  sentry-rails
+  sentry-ruby
+  sentry-sidekiq
   sidekiq
   sidekiq-scheduler
   spring (~> 2.0)

--- a/app/jobs/sentry_job.rb
+++ b/app/jobs/sentry_job.rb
@@ -1,7 +1,0 @@
-class SentryJob < ApplicationJob
-  queue_as :default
-
-  def perform(event)
-    Raven.send_event(event)
-  end
-end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,15 +36,16 @@ module DecidimAws
       ActiveRecord::SessionStore::Session.serializer = :json
     end
 
-    Raven.configure do |config|
-      config.logger = Raven::Logger.new(STDOUT)
+    Sentry.init do |config|
+      config.logger = Sentry::Logger.new(STDOUT)
       config.dsn = "https://c3d3d789cfd241db940fcd8c8c2b81eb@o26574.ingest.sentry.io/5471760" # ENV["SENTRY_DSN"]
-      config.environments = %w[staging production bosa-production bosa-cities-production bosa-uat bosa-cities-uat]
-      config.current_environment = ENV.fetch("SENTRY_CURRENT_ENV", "missing-env")
+      config.enabled_environments = %w[staging production bosa-production bosa-cities-production bosa-uat bosa-cities-uat]
+      config.environment = ENV.fetch("SENTRY_CURRENT_ENV", "missing-env")
+      config.send_default_pii = true
 
-      config.async = lambda { |event|
-        SentryJob.perform_later(event)
-      }
+      config.async = lambda do |event, hint|
+        Sentry::SendEventJob.perform_later(event, hint)
+      end
     end
 
     # config.action_mailer.asset_host = "https://broom.osp.cat"


### PR DESCRIPTION
## Description
- What?
- - Migrate to the new gem
- Why?
- - The old sentry-raven client has entered maintenance mode. If you're using sentry-raven, we recommend you to migrate to this new SDK.
- How?
- - Change the gemfile with the new library and add dependencies. Change application.rb with the new configuration and remove a job because he is managed by the library.
- Anything Else?
- - I was not able to test locally. So you have to test the code once deployed on staging.

## Ticket
[BOSA21Q1-146](https://belighted.atlassian.net/browse/BOSA21Q1-146?atlOrigin=eyJpIjoiZDU2NmY1N2U2ZWY1NDY3Mjg1Y2M4OGNkYTFlZGU4MjIiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [x]  Dependency upgrade
- [ ]  Bug fix
- [ ]  New feature
- [ ]  Breaking changes