### PR TITLE
BOSA21Q1-315 Use a hash of national registry number to link CSAM connection to the right user - fix access namespace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GIT
 
 GIT
   remote: https://github.com/belighted/decidim-module-verifications_omniauth
-  revision: 90154a91c1ea41680e537d033e213ca2c755629a
+  revision: 3c294333935311a17380a38dc495ac6a2eae38cc
   branch: 0.22.0
   specs:
     decidim-verifications_omniauth (0.22.0)


### PR DESCRIPTION
https://github.com/belighted/decidim-module-verifications_omniauth/commit/3c294333935311a17380a38dc495ac6a2eae38cc