### PR TITLE
Dekamer: remove character limitation in title of initiative (BOSA21Q1-166)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ Procfile.dev
 .generators
 
 
+dump.rdb

--- a/lib/extends/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
+++ b/lib/extends/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
@@ -7,6 +7,18 @@ module InitiativeFormExtend
 
   included do
 
+    clear_validators!
+    validates :title, :description, presence: true
+    validates :signature_type, presence: true
+    validates :type_id, presence: true
+    validates :area, presence: true, if: ->(form) { form.area_id.present? }
+    validate :scope_exists
+    validate :notify_missing_attachment_if_errored
+    validate :trigger_attachment_errors
+    validates :signature_end_date, date: { after: Date.current }, if: lambda { |form|
+      form.context.initiative_type.custom_signature_end_date_enabled? && form.signature_end_date.present?
+    }
+
     validates :description, length: {maximum: 4000}
 
     def scope_id


### PR DESCRIPTION
## Description
- What?
- - Remove character limitation in title of initiative
- Why?
- - A title can be longer than 150 characters
- How?
- - Extend initiative form. Before clear all validators. After copy/paste validators from the gem and remove the title length. 

## Ticket
[BOSA21Q1-166](ticket_url)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [ ]  Dependency upgrade
- [ ]  Bug fix
- [x]  New feature
- [ ]  Breaking changes