### PR TITLE
BOSA21Q1-185 BOSA: "follow" button of an initiative/suggestion

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -650,9 +650,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.10)
-      nokogiri (~> 1)
-      rake
+    mimemagic (0.3.5)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GIT
 
 GIT
   remote: https://github.com/belighted/decidim-module-suggestions
-  revision: 83eddcfa309202dd98ce5630235db333a0163134
+  revision: 994b470363e883b623cc3852168e620743389b3a
   branch: 0.22.0
   specs:
     decidim-suggestions (0.22.0)
@@ -650,7 +650,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)

--- a/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -43,14 +43,12 @@ edit_link(
         <%= render partial: "interactions" %>
       </div>
     </div>
-    <% if current_user %>
-      <div class="card text-center follow-section">
-        <div class="card__content">
-          <%= cell "decidim/follow_button", current_participatory_space, inline: false, large: true %>
-          <small><%= t(".follow_description") %></small>
-        </div>
+    <div class="card text-center follow-section">
+      <div class="card__content">
+        <%= cell "decidim/follow_button", current_participatory_space, inline: false, large: true %>
+        <small><%= t(".follow_description") %></small>
       </div>
-    <% end %>
+    </div>
     <% if current_initiative.votes_enabled_state? || current_initiative.accepted? %>
       <%= render partial: "decidim/shared/share_modal" %>
       <%= embed_modal_for initiative_initiative_widget_url(current_initiative, format: :js) %>


### PR DESCRIPTION
## Description
- What?
- - Let the follow button appear even when not connected
- Why?
- - When I click on it, pop up appears saying "To follow this petition/suggestion, please connect + CSAM button" (just the same as when I click on signing button when I'm not connected)
- How?
- - Remove a condition in the show view which shows the button only when the user is logged in. And update the suggestion module where I made the changes earlier.

## Ticket
[BOSA21Q1-185](https://belighted.atlassian.net/browse/BOSA21Q1-185?atlOrigin=eyJpIjoiN2ZhM2QwMmE4YWU5NGNiZDhhMjNjODU1OGQ3ZTY5NTQiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [ ]  Dependency upgrade
- [ ]  Bug fix
- [x]  New feature
- [ ]  Breaking changes