### PR TITLE
BOSA21Q1-224 Rename BOSA dummy authorization (Direct) to "Admin can impersonate users" in the system

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
         name: Omniauth Decidim
         explanation: Validate with your external Decidim account
       dummy_authorization_handler:
-        name: BOSA dummy authorization
+        name: Admin can impersonate users
         explanation: Add additional informations to your account
         fields:
           scope_id: Scope


### PR DESCRIPTION
## Description
- What?
- - Rename BOSA dummy authorization (Direct) to "Admin can impersonate users" in the system
- Why?
- - More understandable
- How?
- - Change en.yml entry
- Anything Else?
- - "(direct)" refers to the name of the strategy, and is found in the identity table, in the provider name attribute
- - !!! Don't forget to push this commit in bosa cities also !!!

## Ticket
[BOSA21Q1-224](https://belighted.atlassian.net/browse/BOSA21Q1-224?atlOrigin=eyJpIjoiMjY4NmRjMWE4NTJiNDM4YzgyOWUwNWMzOWQ3NjNiMDUiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [ ]  Dependency upgrade
- [ ]  Bug fix
- [x]  New feature
- [ ]  Breaking changes