### PR TITLE
fake personal data and remove identities & encrypted data

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -20,18 +20,8 @@ namespace :users do
           email:Faker::Internet.email
         }
 
-        sql = <<-SQL
-        UPDATE decidim_users
-          SET name = '#{attributes[:name]}',
-              last_sign_in_ip = '#{attributes[:last_sign_in_ip]}',
-              nickname = '#{attributes[:nickname]}',
-              email = '#{attributes[:email]}',
-              unconfirmed_email = NULL,
-              updated_at = LOCALTIMESTAMP
-        WHERE id = #{u.id}
-        SQL
+        u.update_columns attributes
 
-        ActiveRecord::Base.connection.execute(Arel.sql(sql))
       end
     end
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+namespace :users do
+  desc "Remove personal data"
+  task remove_personal_data: :environment do
+
+    if Rails.env.production?
+      puts "---------------DANGER---------------"
+      puts "This script cannot run on production"
+      puts "---------------DANGER---------------"
+      return
+    end
+    # Remove information on user
+    Decidim::User.find_in_batches do |users|
+      users.each do |u|
+        u.name = Faker::Name.name
+        u.email = Faker::Internet.email if u.email.present?
+        u.unconfirmed_email = Faker::Internet.email if u.unconfirmed_email.present?
+        u.last_sign_in_ip = "127.0.0.1"
+        u.nickname = Faker::Crypto.sha256[0..15]
+        u.save!
+      end
+    end
+
+    # Remove encrypted data in authorization
+    empty_authorization = "UPDATE decidim_authorizations SET encrypted_metadata = NULL"
+    ActiveRecord::Base.connection.execute(empty_authorization)
+
+    # Remove all identities
+    empty_identities = "TRUNCATE TABLE decidim_identities"
+    ActiveRecord::Base.connection.execute(empty_identities)
+
+  end
+end


### PR DESCRIPTION
## Description
- What?
- - Delete personal data for exporting production data to other environments
- Why?
- - Security
- How?
- - Run the rake tasks `users:remove_personal_data` on an environment that is not production


## Ticket
https://belighted.atlassian.net/browse/BOSA21Q1-330

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [ ]  Dependency upgrade
- [ ]  Bug fix
- [x]  New feature
- [ ]  Breaking changes