### PR TITLE
BOSA21Q1-335, BOSA21Q1-334 Cookies module shouldn't register itself as a component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: https://github.com/belighted/decidim-module-cookies
-  revision: a312864b9b57075d387e1dd96dbfaab05065bf66
+  revision: ead9e4349afb6442d106df52643d557615d09c90
   branch: 0.22.0
   specs:
     decidim-cookies (0.22.0)


### PR DESCRIPTION
**See the code changes in the module**
https://github.com/belighted/decidim-module-cookies/commit/ead9e4349afb6442d106df52643d557615d09c90

**Related tickets**
https://belighted.atlassian.net/browse/BOSA21Q1-335
https://belighted.atlassian.net/browse/BOSA21Q1-334

**Same change/PR for bosa-cities app**
https://github.com/belighted/bosa-cities/pull/20

**What? Why?**
Cookies module was registering itself as a participatory process component, but it doesn't has any logic implemented to support it, and there is no purpose of having it registered as a component at all - there is nothing to do for it.
The change is to remove the registration as a component.