### PR TITLE
BOSA21Q1-246: fix n+1 queries problem in the app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'sidekiq-scheduler'
 gem "uglifier", "~> 4.1"
 gem "wicked_pdf", "~> 1.4"
 gem 'wkhtmltopdf-binary'
+gem 'goldiloader'
 
 gem 'dotenv-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -587,6 +587,9 @@ GEM
     geocoder (1.6.7)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    goldiloader (4.1.0)
+      activerecord (>= 5.2, < 7.1)
+      activesupport (>= 5.2, < 7.1)
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
@@ -1089,6 +1092,7 @@ DEPENDENCIES
   dotenv-rails
   faker (~> 2.14)
   fog-aws
+  goldiloader
   http_logger
   letter_opener_web (~> 1.3)
   listen (~> 3.1)


### PR DESCRIPTION
Updated:

Initially I have fixed n+1 queries for initiative card view. But I was
talking with @gotar about this and he mentioned about https://github.com/salsify/goldiloader gem. In
the result this gem was solved automatically what I have done and
for other places which we don't know. Moreover I decided to keep random
as a default filter option.