### PR TITLE
BOSA21Q1-181 BOSA + BOSA cities: add translations

### DIFF
--- a/lib/extends/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/lib/extends/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module DeviseSessionsControllerExtend
+  extend ActiveSupport::Concern
+
+  included do
+    def after_sign_out_path_for(user)
+      decidim.new_user_session_path
+    end
+  end
+end
+
+Decidim::Devise::SessionsController.send(:include, DeviseSessionsControllerExtend)
+


### PR DESCRIPTION
## Description
- What?
- - Same with this text below, I found the key but the translation doesn’t appear. To arrive on this page, I was connected as an admin in the admin panel, and I simply disconnected.
- Why?
- - Not the good url for logout
- How?
- - Override after_sign_out_path_for in extend to take the good url to logout

!!! Don't forget to push this commit in bosa cities also !!!

## Ticket
[BOSA21Q1-181](https://belighted.atlassian.net/browse/BOSA21Q1-181?atlOrigin=eyJpIjoiOTBmYTUwZGFlMGFlNDRmNzkwYjZhMWFiNDMzYzQxYTgiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [x]  Refactoring
- [ ]  Dependency upgrade
- [ ]  Bug fix
- [ ]  New feature
- [ ]  Breaking changes