### PR TITLE
BOSA21Q1-184 De Kamer: signing button of an initiative, different text

### DIFF
--- a/app/models/decidim/initiative.rb
+++ b/app/models/decidim/initiative.rb
@@ -217,6 +217,7 @@ module Decidim
     end
 
     def votes_enabled?
+      !no_signature &&
       votes_enabled_state? &&
         signature_start_date.present? && signature_start_date <= Date.current &&
         signature_end_date.present? && signature_end_date >= Date.current


### PR DESCRIPTION
## Description
- What?
- - This petition doesn't request signatures. But then you see that on the green button it's written "Please identify to sign this initiative". Those 2 are contradictory.
- Why?
- - If you don't have to sign a petition the button should disappear.
- How?
- - Change de method "votes_enabled?" => add the field no_signature in the condition. 

## Ticket
[BOSA21Q1-184](https://belighted.atlassian.net/browse/BOSA21Q1-184?atlOrigin=eyJpIjoiZDEzNWJlY2M0MTkzNGRjNWIyYzJjYmExNjM0OTQwYzEiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [ ]  Dependency upgrade
- [ ]  Bug fix
- [x]  New feature
- [ ]  Breaking changes