### PR TITLE
BOSA21Q1-246: make tweaks for development assets config

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,7 +55,9 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
+
+  config.assets.digest = false
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true


### PR DESCRIPTION
Updated:

I have disabled the debug option for assets at development, since it
has big performance impact how the app is working. The debug option
should have any influence to preprocessing workflow, but for some
reasons the assets are not properly generated after this change. I
have found that disabling the digest for some cases may solve such a
issue. In our case this combination works fine.