### PR TITLE
BOSA21Q1-16 Front office: in the conversation module > delete the limitation of characters in a conversation

### DIFF
--- a/lib/extends/decidim-core/app/models/decidim/messaging/message.rb
+++ b/lib/extends/decidim-core/app/models/decidim/messaging/message.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module MessageExtend
+  extend ActiveSupport::Concern
+
+  included do
+    clear_validators!
+    validates :sender, :body, presence: true
+
+    validate :sender_is_participant
+  end
+end
+
+Decidim::Messaging::Message.send(:include, MessageExtend)


### PR DESCRIPTION
## Description
- What?
- - As a user, when I send a message to another user through the conversation module, I want to be able to send a message without any characters limitation.
- Why?
- - I know the client tried to enter a huge texte (I don’t have the texte anymore) and i did not work.
- How?
- - Extend Message model and remove the body length limitation => (length: { maximum: 1_000 })

## Ticket
[BOSA21Q1-16](https://belighted.atlassian.net/browse/BOSA21Q1-16?atlOrigin=eyJpIjoiMGE0YmIyZjExZWM1NDI3NDlkNDc1ZjE3YTFiZjZjYTQiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [ ]  Dependency upgrade
- [ ]  Bug fix
- [x]  New feature
- [ ]  Breaking changes