### PR TITLE
BOSA21Q1-170 Bosa & Bosa cities: hide proposals in presentation page of a process

### DIFF
--- a/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -36,7 +36,6 @@
         <%= decidim_sanitize translated_attribute(current_participatory_space.description) %>
       </div>
       <%= attachments_for current_participatory_space %>
-      <%= render_hook(:participatory_space_highlighted_elements) %>
 
       <% if related_processes.any? %>
         <div class="section row collapse related_processes">


### PR DESCRIPTION
## Description
- What?
- - On the presentation page of a process is it possible to delete the blocks below the page which show a preview existing proposals?
- Why?
- - The preview confuses the user (cfr delphine)
- How?
- - Remove highlighted_elements on participatory_process/show view

## Ticket
[BOSA21Q1-170](https://belighted.atlassian.net/browse/BOSA21Q1-170?atlOrigin=eyJpIjoiYTUwZjkwYzA1MjIxNGRhNmEzYmUxNjY1YzcyYTg5NjIiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [ ]  Dependency upgrade
- [ ]  Bug fix
- [x]  New feature
- [ ]  Breaking changes
