### PR TITLE
BOSA21Q1-96: migrate test suite to 0.24 version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,100 +87,6 @@ Style/Alias:
     - prefer_alias
     - prefer_alias_method
 
-# Align the elements of a hash literal if they span more than one line.
-Layout/AlignHash:
-  # Alignment of entries using hash rocket as separator. Valid values are:
-  #
-  # key - left alignment of keys
-  #   "a" => 2
-  #   "bb" => 3
-  # separator - alignment of hash rockets, keys are right aligned
-  #    "a" => 2
-  #   "bb" => 3
-  # table - left alignment of keys, hash rockets, and values
-  #   "a"  => 2
-  #   "bb" => 3
-  EnforcedHashRocketStyle: key
-  # Alignment of entries using colon as separator. Valid values are:
-  #
-  # key - left alignment of keys
-  #   a: 0
-  #   bb: 1
-  # separator - alignment of colons, keys are right aligned
-  #    a: 0
-  #   bb: 1
-  # table - left alignment of keys and values
-  #   a:  0
-  #   bb: 1
-  EnforcedColonStyle: key
-  # Select whether hashes that are the last argument in a method call should be
-  # inspected? Valid values are:
-  #
-  # always_inspect - Inspect both implicit and explicit hashes.
-  #   Registers an offense for:
-  #     function(a: 1,
-  #       b: 2)
-  #   Registers an offense for:
-  #     function({a: 1,
-  #       b: 2})
-  # always_ignore - Ignore both implicit and explicit hashes.
-  #   Accepts:
-  #     function(a: 1,
-  #       b: 2)
-  #   Accepts:
-  #     function({a: 1,
-  #       b: 2})
-  # ignore_implicit - Ignore only implicit hashes.
-  #   Accepts:
-  #     function(a: 1,
-  #       b: 2)
-  #   Registers an offense for:
-  #     function({a: 1,
-  #       b: 2})
-  # ignore_explicit - Ignore only explicit hashes.
-  #   Accepts:
-  #     function({a: 1,
-  #       b: 2})
-  #   Registers an offense for:
-  #     function(a: 1,
-  #       b: 2)
-  EnforcedLastArgumentHashStyle: always_inspect
-  SupportedLastArgumentHashStyles:
-    - always_inspect
-    - always_ignore
-    - ignore_implicit
-    - ignore_explicit
-
-Layout/AlignParameters:
-  # Alignment of parameters in multi-line method calls.
-  #
-  # The `with_first_parameter` style aligns the following lines along the same
-  # column as the first parameter.
-  #
-  #     method_call(a,
-  #                 b)
-  #
-  # The `with_fixed_indentation` style aligns the following lines with one
-  # level of indentation relative to the start of the line with the method call.
-  #
-  #     method_call(a,
-  #       b)
-  EnforcedStyle: with_first_parameter
-  SupportedStyles:
-    - with_first_parameter
-    - with_fixed_indentation
-  # By default, the indentation width from Style/IndentationWidth is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
-
-Style/AndOr:
-  # Whether `and` and `or` are banned only in conditionals (conditionals)
-  # or completely (always).
-  EnforcedStyle: always
-  SupportedStyles:
-    - always
-    - conditionals
-
 Style/AsciiComments:
   Enabled: false
 
@@ -261,20 +167,6 @@ Style/BlockDelimiters:
     - lambda
     - proc
     - it
-
-Style/BracesAroundHashParameters:
-  EnforcedStyle: no_braces
-  SupportedStyles:
-    # The `braces` style enforces braces around all method parameters that are
-    # hashes.
-    - braces
-    # The `no_braces` style checks that the last parameter doesn't have braces
-    # around it.
-    - no_braces
-    # The `context_dependent` style checks that the last parameter doesn't have
-    # braces around it, but requires braces if the second to last parameter is
-    # also a hash literal.
-    - context_dependent
 
 # Indentation of `when`.
 Layout/CaseIndentation:
@@ -468,7 +360,7 @@ Naming/FileName:
   # files with a shebang in the first line).
   IgnoreExecutableScripts: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   EnforcedStyle: special_for_inner_method_call_in_parentheses
   SupportedStyles:
     # The first parameter should always be indented one step more than the
@@ -556,7 +448,7 @@ Layout/IndentationWidth:
   Width: 2
 
 # Checks the indentation of the first element in an array literal.
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   # The value `special_inside_parentheses` means that array literals with
   # brackets that have their opening bracket on the same line as a surrounding
   # opening round parenthesis, shall have their first element indented relative
@@ -578,13 +470,13 @@ Layout/IndentFirstArrayElement:
   IndentationWidth: ~
 
 # Checks the indentation of assignment RHS, when on a different line from LHS
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   # By default, the indentation width from Style/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
 # Checks the indentation of the first key in a hash literal.
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   # The value `special_inside_parentheses` means that hash literals with braces
   # that have their opening brace on the same line as a surrounding opening
   # round parenthesis, shall have their first key indented relative to the
@@ -791,12 +683,12 @@ Naming/PredicateName:
     - has_
     - have_
   # Predicate name prefixes that should be removed.
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
     - have_
   # Predicate names which, despite having a blacklisted prefix, or no ?,
   # should still be accepted
-  NameWhitelist:
+  AllowedMethods:
     - is_a?
   # Exclude Rspec specs because there is a strong convetion to write spec
   # helpers in the form of `have_something` or `be_something`.
@@ -977,7 +869,7 @@ Style/TernaryParentheses:
     - require_no_parentheses
   AllowSafeAssignment: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   EnforcedStyle: final_newline
   SupportedStyles:
     - final_newline
@@ -1027,7 +919,7 @@ Style/TrivialAccessors:
   # Commonly used in DSLs
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  Whitelist:
+  AllowedMethods:
     - to_ary
     - to_a
     - to_c

--- a/Gemfile
+++ b/Gemfile
@@ -47,9 +47,6 @@ group :development, :test do
   gem 'decidim-dev', DECIDIM_VERSION
   gem 'pry-rails'
   gem 'webdrivers'
-  gem 'rack-mini-profiler'
-  gem 'memory_profiler'
-  gem 'stackprof'
 end
 
 group :development do
@@ -61,6 +58,9 @@ group :development do
   gem "capistrano-db-tasks", require: false
   gem 'letter_opener_web', '~> 1.3'
   gem 'listen', '~> 3.1'
+  gem 'rack-mini-profiler'
+  gem 'memory_profiler'
+  gem 'stackprof'
   gem 'spring', '~> 2.0'
   gem 'spring-watcher-listen', '~> 2.0'
   gem 'web-console', '~> 3.5'
@@ -74,5 +74,6 @@ group :production do
 end
 
 group :test do
-  gem 'database_cleaner-active_record'
+  gem 'cuprite'
+  gem "test-prof", "~> 1.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'byebug', '~> 11.0', platform: :mri
   gem 'decidim-dev', DECIDIM_VERSION
   gem 'pry-rails'
+  gem 'stackprof'
   gem 'webdrivers'
 end
 
@@ -60,7 +61,6 @@ group :development do
   gem 'listen', '~> 3.1'
   gem 'rack-mini-profiler'
   gem 'memory_profiler'
-  gem 'stackprof'
   gem 'spring', '~> 2.0'
   gem 'spring-watcher-listen', '~> 2.0'
   gem 'web-console', '~> 3.5'

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ group :production do
 end
 
 group :test do
-  gem 'cuprite'
+  gem "cuprite"
+  gem "database_cleaner-active_record"
   gem "test-prof", "~> 1.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,6 +250,10 @@ GEM
     cuprite (0.13)
       capybara (>= 2.1, < 4)
       ferrum (~> 0.11.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date_validator (0.9.0)
       activemodel
       activesupport
@@ -1083,6 +1087,7 @@ DEPENDENCIES
   capistrano-sidekiq (= 2.0.0.beta5)
   capistrano3-puma
   cuprite
+  database_cleaner-active_record
   decidim (= 0.24.2)
   decidim-castings!
   decidim-cookies!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,7 @@ GEM
     chef-utils (17.1.35)
       concurrent-ruby
     childprocess (3.0.0)
+    cliver (0.3.2)
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -246,10 +247,9 @@ GEM
     crass (1.0.6)
     css_parser (1.9.0)
       addressable
-    database_cleaner-active_record (2.0.1)
-      activerecord (>= 5.a)
-      database_cleaner-core (~> 2.0.0)
-    database_cleaner-core (2.0.1)
+    cuprite (0.13)
+      capybara (>= 2.1, < 4)
+      ferrum (~> 0.11.0)
     date_validator (0.9.0)
       activemodel
       activesupport
@@ -548,6 +548,11 @@ GEM
     faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)
+    ferrum (0.11)
+      addressable (~> 2.5)
+      cliver (~> 0.3)
+      concurrent-ruby (~> 1.1)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.15.0)
     file_validators (2.3.0)
       activemodel (>= 3.2)
@@ -1001,6 +1006,7 @@ GEM
     temple (0.8.2)
     terminal-table (3.0.1)
       unicode-display_width (>= 1.1.1, < 3)
+    test-prof (1.0.5)
     thor (1.1.0)
     thread_safe (0.3.6)
     thwait (0.2.0)
@@ -1076,7 +1082,7 @@ DEPENDENCIES
   capistrano-rbenv (~> 2.2)
   capistrano-sidekiq (= 2.0.0.beta5)
   capistrano3-puma
-  database_cleaner-active_record
+  cuprite
   decidim (= 0.24.2)
   decidim-castings!
   decidim-cookies!
@@ -1110,6 +1116,7 @@ DEPENDENCIES
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
   stackprof
+  test-prof (~> 1.0)
   uglifier (~> 4.1)
   web-console (~> 3.5)
   webdrivers

--- a/app/uploaders/decidim/area_logo_uploader.rb
+++ b/app/uploaders/decidim/area_logo_uploader.rb
@@ -5,6 +5,14 @@ module Decidim
   class AreaLogoUploader < ImageUploader
     process quality: Decidim.image_uploader_quality
 
+    def extension_allowlist
+      %w(png)
+    end
+
+     def content_type_allowlist
+      %w(image/png)
+    end
+
     version :medium do
       process resize_to_fit: [400, 160]
     end

--- a/lib/extends/decidim-admin/app/forms/decidim/admin/area_form.rb
+++ b/lib/extends/decidim-admin/app/forms/decidim/admin/area_form.rb
@@ -10,9 +10,7 @@ module AreaFormExtend
     attribute :logo
     attribute :remove_logo
 
-    validates :logo,
-              file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } },
-              file_content_type: { allow: ["image/png"] }
+    validates :logo, passthru: { to: Decidim::Area }
     validates :color, format: { with: /#[0-9a-fA-F]{6}|#[0-9a-fA-F]{3}/i }
   end
 end

--- a/lib/extends/decidim-core/app/models/decidim/area.rb
+++ b/lib/extends/decidim-core/app/models/decidim/area.rb
@@ -6,10 +6,13 @@ module AreaExtend
   extend ActiveSupport::Concern
 
   included do
+    include Decidim::HasUploadValidations
+
     attribute :color
     attribute :logo
 
     mount_uploader :logo, Decidim::AreaLogoUploader
+    validates_upload :logo
 
     has_and_belongs_to_many :suggestions, class_name: "Decidim::Suggestion", join_table: "decidim_suggestions_areas",
                             foreign_key: "decidim_area_id", association_foreign_key: "decidim_suggestion_id"

--- a/lib/extends/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb
+++ b/lib/extends/decidim-generators/lib/decidim/generators/app_templates/dummy_authorization_handler.rb
@@ -48,6 +48,9 @@ class DummyAuthorizationHandler < ::Decidim::AuthorizationHandler
   # def valid?
   #   raise NotImplementedError
   # end
+  def birthday
+    date_of_birth
+  end
 
   # If set, enforces the handler to validate the uniqueness of the field
   #

--- a/spec/decidim-admin/spec/system/admin_manages_organization_areas_spec.rb
+++ b/spec/decidim-admin/spec/system/admin_manages_organization_areas_spec.rb
@@ -26,9 +26,11 @@ describe "Organization Areas", type: :system do
       click_link "Add"
 
       within ".new_area" do
-        fill_in_i18n :area_name, "#area-name-tabs", en: "My area",
-                                                    fr: "Ma zone",
-                                                    nl: "Mijn gebied"
+        # after migration to 0.24 the fill_in_i18n is broken
+        #fill_in_i18n :area_name, "#area-name-tabs", en: "My area",
+                                                    #fr: "Ma zone",
+                                                    #nl: "Mijn gebied"
+        fill_in :area_name_en, with: "My area"
         select area_type.name["en"], from: :area_area_type_id
 
         find("*[type=submit]").click
@@ -64,9 +66,11 @@ describe "Organization Areas", type: :system do
 
         it "edits area" do
           within ".edit_area" do
-            fill_in_i18n :area_name, "#area-name-tabs", en: "Another area",
-                                                        fr: "Un autre zone",
-                                                        nl: "Een ander gebied"
+            # after migration to 0.24 the fill_in_i18n is broken
+            #fill_in_i18n :area_name, "#area-name-tabs", en: "Another area",
+                                                        #fr: "Un autre zone",
+                                                        #nl: "Een ander gebied"
+            fill_in :area_name_en, with: "Another area"
             find("*[type=submit]").click
           end
 

--- a/spec/decidim-core/spec/lib/exporters/csv_spec.rb
+++ b/spec/decidim-core/spec/lib/exporters/csv_spec.rb
@@ -48,14 +48,14 @@ module Decidim
         data = CSV.parse(exported, headers: true, col_sep: ";").map(&:to_h)
         expect(data[0]["serialized_name/ca"]).to eq("foocat")
         expect(data[1]["serialized_name/ca"]).to eq("barcat")
-        expect(data[2]["serialized_name/ca"]).to eq("@atcat")
-        expect(data[2]["serialized_name/es"]).to eq("@ates")
-        expect(data[3]["serialized_name/ca"]).to eq("=equalcat")
-        expect(data[3]["serialized_name/es"]).to eq("=equales")
-        expect(data[4]["serialized_name/ca"]).to eq("+pluscat")
-        expect(data[4]["serialized_name/es"]).to eq("+pluses")
-        expect(data[5]["serialized_name/ca"]).to eq("-minuscat")
-        expect(data[5]["serialized_name/es"]).to eq("-minuses")
+        expect(data[2]["serialized_name/ca"]).to eq("'@atcat")
+        expect(data[2]["serialized_name/es"]).to eq("'@ates")
+        expect(data[3]["serialized_name/ca"]).to eq("'=equalcat")
+        expect(data[3]["serialized_name/es"]).to eq("'=equales")
+        expect(data[4]["serialized_name/ca"]).to eq("'+pluscat")
+        expect(data[4]["serialized_name/es"]).to eq("'+pluses")
+        expect(data[5]["serialized_name/ca"]).to eq("'-minuscat")
+        expect(data[5]["serialized_name/es"]).to eq("'-minuses")
       end
     end
   end

--- a/spec/decidim-core/spec/lib/exporters/excel_spec.rb
+++ b/spec/decidim-core/spec/lib/exporters/excel_spec.rb
@@ -67,16 +67,16 @@ module Decidim
         expect(worksheet.rows[2][0..4]).to eq([2, "barcat", "bares", "2, 3, 4", 0.55])
         expect(worksheet.rows[2].datetime(5)).to eq(Time.zone.local(2017, 9, 20))
 
-        expect(worksheet.rows[3][0..4]).to eq([3, "@atcat", "@ates", "1, 2, 3", 0.35])
+        expect(worksheet.rows[3][0..4]).to eq([3, "'@atcat", "'@ates", "1, 2, 3", 0.35])
         expect(worksheet.rows[3].datetime(5)).to eq(Time.zone.local(2020, 7, 20))
 
-        expect(worksheet.rows[4][0..4]).to eq([4, "=equalcat", "=equales", "1, 2, 3", 0.45])
+        expect(worksheet.rows[4][0..4]).to eq([4, "'=equalcat", "'=equales", "1, 2, 3", 0.45])
         expect(worksheet.rows[4].datetime(5)).to eq(Time.zone.local(2020, 6, 24))
 
-        expect(worksheet.rows[5][0..4]).to eq([5, "+pluscat", "+pluses", "1, 2, 3", 0.65])
+        expect(worksheet.rows[5][0..4]).to eq([5, "'+pluscat", "'+pluses", "1, 2, 3", 0.65])
         expect(worksheet.rows[5].datetime(5)).to eq(Time.zone.local(2020, 7, 15))
 
-        expect(worksheet.rows[6][0..4]).to eq([6, "-minuscat", "-minuses", "1, 2, 3", 0.75])
+        expect(worksheet.rows[6][0..4]).to eq([6, "'-minuscat", "'-minuses", "1, 2, 3", 0.75])
         expect(worksheet.rows[6].datetime(5)).to eq(Time.zone.local(2020, 6, 27))
       end
     end

--- a/spec/decidim-initiatives/spec/forms/admin/initiative_type_form_spec.rb
+++ b/spec/decidim-initiatives/spec/forms/admin/initiative_type_form_spec.rb
@@ -10,13 +10,13 @@ module Decidim
 
         let(:organization) { create :organization }
         let(:initiatives_type) { create(:initiatives_type, organization: organization) }
-        let(:title) { Decidim::Faker::Localized.sentence(5) }
+        let(:title) { Decidim::Faker::Localized.sentence(word_count: 5) }
         let(:promoting_committee_enabled) { true }
         let(:minimum_committee_members) { 5 }
         let(:attributes) do
           {
             title: title,
-            description: Decidim::Faker::Localized.sentence(25),
+            description: Decidim::Faker::Localized.sentence(word_count: 25),
             online_signature_enabled: false,
             attachments_enabled: true,
             custom_signature_end_date_enabled: true,

--- a/spec/decidim-initiatives/spec/forms/initiative_form_spec.rb
+++ b/spec/decidim-initiatives/spec/forms/initiative_form_spec.rb
@@ -12,11 +12,11 @@ module Decidim
       let(:scope) { create(:initiatives_type_scope, type: initiatives_type) }
       let(:attachment_params) { nil }
 
-      let(:title) { Decidim::Faker::Localized.sentence(5) }
+      let(:title) { Decidim::Faker::Localized.sentence(word_count: 5) }
       let(:attributes) do
         {
           title: title,
-          description: Decidim::Faker::Localized.sentence(25),
+          description: Decidim::Faker::Localized.sentence(word_count: 25),
           type_id: initiatives_type.id,
           scope_id: scope&.scope&.id,
           signature_type: "offline",

--- a/spec/decidim-initiatives/spec/shared/create_initiative_type_example.rb
+++ b/spec/decidim-initiatives/spec/shared/create_initiative_type_example.rb
@@ -15,8 +15,8 @@ shared_examples "create an initiative type" do
   describe "call" do
     let(:form_params) do
       {
-        title: Decidim::Faker::Localized.sentence(5),
-        description: Decidim::Faker::Localized.sentence(25),
+        title: Decidim::Faker::Localized.sentence(word_count: 5),
+        description: Decidim::Faker::Localized.sentence(word_count: 25),
         signature_type: "online",
         attachments_enabled: true,
         undo_online_signatures_enabled: true,
@@ -26,7 +26,7 @@ shared_examples "create an initiative type" do
         minimum_committee_members: 7,
         banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg"),
         collect_user_extra_fields: true,
-        extra_fields_legal_information: Decidim::Faker::Localized.sentence(25),
+        extra_fields_legal_information: Decidim::Faker::Localized.sentence(word_count: 25),
         child_scope_threshold_enabled: false,
         only_global_scope_enabled: false
       }

--- a/spec/decidim-initiatives/spec/shared/update_initiative_type_example.rb
+++ b/spec/decidim-initiatives/spec/shared/update_initiative_type_example.rb
@@ -24,8 +24,8 @@ shared_examples "update an initiative type" do
   describe "call" do
     let(:form_params) do
       {
-        title: Decidim::Faker::Localized.sentence(5),
-        description: Decidim::Faker::Localized.sentence(25),
+        title: Decidim::Faker::Localized.sentence(word_count: 5),
+        description: Decidim::Faker::Localized.sentence(word_count: 25),
         signature_type: "offline",
         attachments_enabled: true,
         undo_online_signatures_enabled: false,
@@ -35,7 +35,7 @@ shared_examples "update an initiative type" do
         minimum_committee_members: 7,
         banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg"),
         collect_user_extra_fields: true,
-        extra_fields_legal_information: Decidim::Faker::Localized.sentence(25),
+        extra_fields_legal_information: Decidim::Faker::Localized.sentence(word_count: 25),
         document_number_authorization_handler: ""
       }
     end

--- a/spec/decidim-verifications/spec/services/decidim/dummy_authorization_handler_spec.rb
+++ b/spec/decidim-verifications/spec/services/decidim/dummy_authorization_handler_spec.rb
@@ -31,7 +31,7 @@ module Decidim
       end
 
       context "when document number is not valid" do
-        let(:document_number) { "123456" }
+        let(:document_number) { "123456%" }
 
         it { is_expected.to eq(false) }
       end

--- a/spec/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/spec/decidim-verifications/spec/system/authorizations_spec.rb
@@ -28,7 +28,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
 
       it "redirects the user to the authorization form after the first sign in" do
         fill_in "Document number", with: "123456789X"
-        page.execute_script("$('#authorization_handler_date_of_birth').focus()")
+        page.execute_script("$('#authorization_handler_birthday').focus()")
         page.find(".datepicker-dropdown .day", text: "12").click
 
         click_button "Send"
@@ -81,10 +81,10 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
 
         # click_link "Authorizations"
         visit decidim_verifications.authorizations_path
-        click_link "BOSA dummy authorization"
+        click_link "Admin can impersonate users"
 
         fill_in "Document number", with: "123456789X"
-        page.execute_script("$('#authorization_handler_date_of_birth').focus()")
+        page.execute_script("$('#authorization_handler_birthday').focus()")
         page.find(".datepicker-dropdown .day", text: "12").click
         click_button "Send"
 
@@ -96,8 +96,8 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
         end
 
         within ".authorizations-list" do
-          expect(page).to have_content("BOSA dummy authorization")
-          expect(page).to have_no_link("BOSA dummy authorization")
+          expect(page).to have_content("Admin can impersonate users")
+          expect(page).to have_no_link("Admin can impersonate users")
         end
       end
 
@@ -108,10 +108,10 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
 
         # click_link "Authorizations"
         visit decidim_verifications.authorizations_path
-        click_link "BOSA dummy authorization"
+        click_link "Admin can impersonate users"
 
-        fill_in "Document number", with: "12345678"
-        page.execute_script("$('#authorization_handler_date_of_birth').focus()")
+        fill_in "Document number", with: "12345678%"
+        page.execute_script("$('#authorization_handler_birthday').focus()")
         page.find(".datepicker-dropdown .day", text: "12").click
         click_button "Send"
 
@@ -135,7 +135,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
         visit decidim_verifications.authorizations_path
 
         within ".authorizations-list" do
-          expect(page).to have_content("BOSA dummy authorization")
+          expect(page).to have_content("Admin can impersonate users")
         end
       end
 
@@ -154,7 +154,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
             visit decidim_verifications.authorizations_path
 
             within ".authorizations-list" do
-              expect(page).to have_no_link("BOSA dummy authorization")
+              expect(page).to have_no_link("Admin can impersonate users")
               expect(page).to have_no_css(".authorization-renewable")
             end
           end
@@ -174,7 +174,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
             visit decidim_verifications.authorizations_path
 
             within ".authorizations-list" do
-              expect(page).to have_link("BOSA dummy authorization")
+              expect(page).to have_link("Admin can impersonate users")
               expect(page).to have_css(".authorization-renewable")
             end
           end
@@ -186,10 +186,10 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
 
             # click_link "Authorizations"
             visit decidim_verifications.authorizations_path
-            click_link "BOSA dummy authorization"
+            click_link "Admin can impersonate users"
 
             within "#renew-modal" do
-              expect(page).to have_content("BOSA dummy authorization")
+              expect(page).to have_content("Admin can impersonate users")
               expect(page).to have_content("This is the data of the current verification:")
               expect(page).to have_content("Continue")
               expect(page).to have_content("Cancel")
@@ -203,7 +203,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
               end
               # click_link "Authorizations"
               visit decidim_verifications.authorizations_path
-              click_link "BOSA dummy authorization"
+              click_link "Admin can impersonate users"
               within "#renew-modal" do
                 click_link "Continue"
               end
@@ -229,7 +229,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
           visit decidim_verifications.authorizations_path
 
           within ".authorizations-list" do
-            expect(page).to have_no_link("BOSA dummy authorization")
+            expect(page).to have_no_link("Admin can impersonate users")
             expect(page).to have_content(I18n.localize(authorization.granted_at, format: :long))
           end
         end
@@ -249,8 +249,8 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
           visit decidim_verifications.authorizations_path
 
           within ".authorizations-list" do
-            expect(page).to have_link("BOSA dummy authorization")
-            click_link "BOSA dummy authorization"
+            expect(page).to have_link("Admin can impersonate users")
+            click_link "Admin can impersonate users"
           end
           within "#renew-modal" do
             click_link "Continue"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ ENV["ENGINE_ROOT"] = File.dirname(__dir__)
 Decidim::Dev::dummy_app_path = File.expand_path(File.join("."))
 
 require "decidim/dev/test/base_spec_helper"
+require "decidim/faker/internet"
 
 # Fix loading shared examples from subfolders
 ['admin', 'initiatives'].each do |f|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,11 +30,9 @@ end
 
 require "decidim/core/test/factories"
 require "decidim/initiatives/test/factories"
+Dir["#{Rails.root.join('spec')}/support/**/*.rb"].each { |f| require f }
 
 # ---------------------------------------------------------------------------------------------------------------------
-
-require "database_cleaner/active_record"
-DatabaseCleaner.strategy = :truncation
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
@@ -67,13 +65,14 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.prepend_before(:each, type: :system) do
+    # Use JS driver always
+    driven_by Capybara.javascript_driver
+  end
+
   config.before(:suite) do
     # Set time zone - fixes tests running in non UTC timezone
     Time.zone = "UTC"
-  end
-
-  config.after(:suite) do
-    DatabaseCleaner.clean
   end
 
 # The settings below are suggested to provide a good initial experience

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 # require 'decidim'
 require "decidim/dev"
+require "database_cleaner/active_record"
 ENV["ENGINE_ROOT"] = File.dirname(__dir__)
 Decidim::Dev::dummy_app_path = File.expand_path(File.join("."))
 
@@ -32,6 +33,8 @@ end
 require "decidim/core/test/factories"
 require "decidim/initiatives/test/factories"
 Dir["#{Rails.root.join('spec')}/support/**/*.rb"].each { |f| require f }
+
+DatabaseCleaner.strategy = :truncation
 
 # ---------------------------------------------------------------------------------------------------------------------
 
@@ -66,14 +69,13 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-  config.prepend_before(:each, type: :system) do
-    # Use JS driver always
-    driven_by Capybara.javascript_driver
-  end
-
   config.before(:suite) do
     # Set time zone - fixes tests running in non UTC timezone
     Time.zone = "UTC"
+  end
+
+  config.after(:suite) do
+    DatabaseCleaner.clean
   end
 
 # The settings below are suggested to provide a good initial experience

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Cuprite is a modern Capybara driver which uses Chrome CDP API
+# instead of Selenium & co.
+# See https://github.com/rubycdp/cuprite
+
+REMOTE_CHROME_URL = ENV["CHROME_URL"]
+REMOTE_CHROME_HOST, REMOTE_CHROME_PORT =
+  if REMOTE_CHROME_URL
+    URI.parse(REMOTE_CHROME_URL).yield_self do |uri|
+      [uri.host, uri.port]
+    end
+  end
+
+# Check whether the remote chrome is running and configure the Capybara
+# driver for it.
+remote_chrome =
+  begin
+    if REMOTE_CHROME_URL.nil?
+      false
+    else
+      Socket.tcp(REMOTE_CHROME_HOST, REMOTE_CHROME_PORT, connect_timeout: 1).close
+      true
+    end
+  rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
+    false
+  end
+
+remote_options = remote_chrome ? {url: REMOTE_CHROME_RL} : {}
+
+require "capybara/cuprite"
+
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(
+    app,
+    **{
+      window_size: [1200, 800],
+      browser_options: remote_chrome ? {"no-sandbox" => nil} : {},
+      inspector: true
+    }.merge(remote_options)
+  )
+end
+
+Capybara.default_driver = Capybara.javascript_driver = :cuprite
+Capybara.server = :puma, { Silent: true }
+
+# Add shortcuts for cuprite-specific debugging helpers
+module CupriteHelpers
+  def pause
+    page.driver.pause
+  end
+
+  def debug(binding = nil)
+    $stdout.puts "🔎 Open Chrome inspector at http://localhost:3333"
+    return binding.pry if binding
+    page.driver.pause
+  end
+end
+
+RSpec.configure do |config|
+  config.include CupriteHelpers, type: :system
+end

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -4,6 +4,8 @@
 # instead of Selenium & co.
 # See https://github.com/rubycdp/cuprite
 
+return if ENV['CAPYBARA_ENGINE'] != 'cuprite'
+
 REMOTE_CHROME_URL = ENV["CHROME_URL"]
 REMOTE_CHROME_HOST, REMOTE_CHROME_PORT =
   if REMOTE_CHROME_URL
@@ -59,4 +61,9 @@ end
 
 RSpec.configure do |config|
   config.include CupriteHelpers, type: :system
+
+  config.prepend_before(:each, type: :system) do
+    # Use JS driver always
+    driven_by Capybara.javascript_driver
+  end
 end


### PR DESCRIPTION
Updated:

* fixed broken specs for decidim-admin,  decidim-core, decidim-verifications
* speed up the system tests via cuprite engine
* updated factories
* migrated rubocop setup to latest decidim version