### PR TITLE
NT: revert Gemfile.lock changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1074,7 +1074,7 @@ DEPENDENCIES
   wkhtmltopdf-binary
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.6.6p146
 
 BUNDLED WITH
-   2.2.19
+   2.1.4


### PR DESCRIPTION
Updated:

I have reverted Bundler and Ruby version to use the same like for
building the app images