### PR TITLE
BOSA21Q1-370 Issue when person doesn't exist in Person Services (UAT only)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GIT
 
 GIT
   remote: https://github.com/belighted/decidim-module-verifications_omniauth
-  revision: 05fd7eacfa857467df7c058e1a4c3732ec9bde75
+  revision: 94741de7cb891d11bf45bb6fb3440b7012460d1c
   branch: 0.22.0
   specs:
     decidim-verifications_omniauth (0.22.0)


### PR DESCRIPTION
## Description
- What?
- - Error 500 when person doesn't exist in Person Service
- Why?
- - Answer return by CSAM is nil and the predefined_nickname make an error
- How?
- - Update gemfile.lock to refer of the last version of decidim module verifications_omniauth

## Ticket
[BOSA21Q1-370](https://belighted.atlassian.net/browse/BOSA21Q1-370?atlOrigin=eyJpIjoiYTI5MjdjYWVhOGYyNDllNTlmMWI3ZTVkYTNkNDczZGUiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [ ]  Dependency upgrade
- [x]  Bug fix
- [ ]  New feature
- [ ]  Breaking changes
