### PR TITLE
BOSA21Q1-387 On a suggestion page, make the name of the author clickable to see his public profile (as on initiative)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GIT
 
 GIT
   remote: https://github.com/belighted/decidim-module-suggestions
-  revision: 03fab5ec8f4e31920c82e0b7b6d1c32f25bc268b
+  revision: 6a6262b6bff1a8e825e62ce33a5a234b6c51ad70
   branch: 0.22.0
   specs:
     decidim-suggestions (0.22.0)


### PR DESCRIPTION
## Description
- What?
- - Add hyperlink in the suggestion show view on the author name like on the index view
- Why?
- - Have the same way of working
- How?
- - Update gemfile.lock to refer of the last version of decidim module suggestion

## Ticket
[BOSA21Q1-387](https://belighted.atlassian.net/browse/BOSA21Q1-387?atlOrigin=eyJpIjoiNzYzNDczYTFkYWE0NDBjZjhkYTM3MGE0MDJiYTNmMjEiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [x]  Dependency upgrade
- [ ]  Bug fix
- [ ]  New feature
- [ ]  Breaking changes