### PR TITLE
BOSA21Q1-341: recover translation option for comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'activerecord-session_store'
 gem "bootsnap", "~> 1.3"
 gem 'deepl-rb'
 gem 'goldiloader'
-gem 'http_logger'
 gem 'omniauth-rails_csrf_protection'
 gem "puma", ">= 5.0.0"
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       gyoku (>= 0.4.0)
       nokogiri
     anchored (1.1.0)
-    appsignal (3.0.5)
+    appsignal (3.0.7)
       rack
     arel (9.0.0)
     ast (2.4.2)
@@ -604,7 +604,6 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    http_logger (0.6.0)
     http_parser.rb (0.6.0)
     httpi (2.4.5)
       rack
@@ -1093,7 +1092,6 @@ DEPENDENCIES
   faker (~> 2.14)
   fog-aws
   goldiloader
-  http_logger
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
   memory_profiler

--- a/app/assets/javascripts/decidim/translations.js.es6
+++ b/app/assets/javascripts/decidim/translations.js.es6
@@ -1,4 +1,4 @@
-let translate = function (originalText, targetLang, callback) {
+let translate = function (originalText, targetLang, callback, errorCallback) {
   if (originalText !== "" && targetLang !== "") {
     $.ajax({
       url: "/api/translate",
@@ -17,7 +17,8 @@ let translate = function (originalText, targetLang, callback) {
 
         callback(response);
       },
-      error: function (_body, _status, error) {
+      error: function (response, status) {
+        if (errorCallback) errorCallback(response, status);
         throw error;
       }
     });
@@ -54,6 +55,9 @@ $(() => {
 
         $item.data("title", $title.text());
         $title.text(response[1]);
+      }, (reponse) => {
+        $spinner.addClass("loading-spinner--hidden");
+        $item.data("translatable", false);
       });
 
       translate(originalBody, targetLang, (response) => {
@@ -69,6 +73,9 @@ $(() => {
         $btn.text(translated);
 
 
+        $item.data("translatable", false);
+      }, (reponse) => {
+        $spinner.addClass("loading-spinner--hidden");
         $item.data("translatable", false);
       });
     } else {

--- a/app/assets/javascripts/decidim/translations.js.es6
+++ b/app/assets/javascripts/decidim/translations.js.es6
@@ -11,9 +11,13 @@ let translate = function (originalText, targetLang, callback) {
       },
       dataType: "json",
       success: function (body) {
-        callback([body.translations[0].detected_source_language, body.translations[0].text]);
+        const response = body.translations !== undefined
+          ? [body.translations[0].detected_source_language, body.translations[0].text]
+          : null;
+
+        callback(response);
       },
-      error: function (body, status, error) {
+      error: function (_body, _status, error) {
         throw error;
       }
     });
@@ -44,17 +48,26 @@ $(() => {
       $spinner.removeClass("loading-spinner--hidden");
 
       translate(originalTitle, targetLang, (response) => {
+        if(response === null) {
+          return;
+        }
+
         $item.data("title", $title.text());
         $title.text(response[1]);
       });
 
       translate(originalBody, targetLang, (response) => {
+        $spinner.addClass("loading-spinner--hidden");
+
+        if(response === null) {
+          return;
+        }
+
         $item.data("body", $body.html());
         $body.html(response[1]);
 
         $btn.text(translated);
 
-        $spinner.addClass("loading-spinner--hidden");
 
         $item.data("translatable", false);
       });

--- a/app/cells/decidim/comments/comment/show.erb
+++ b/app/cells/decidim/comments/comment/show.erb
@@ -12,14 +12,15 @@
       </div>
     </div>
   </div>
-  <div class="comment__content">
+  <div id="comment_<%= model.id %>_body" class="comment__content">
     <%= alignment_badge %>
     <%= comment_body %>
-
-    <% if translatable? %>
-      <%= translate_button_helper_for(title: "", body: comment_body, model: model) %>
-    <% end %>
   </div>
+  <% if translatable? %>
+    <div class="comment__content">
+        <%= translate_button_helper_for(title: "", body: comment_body, model: model) %>
+    </div>
+  <% end %>
   <div class="comment__footer">
     <%= render :actions %>
     <%= votes %>

--- a/app/cells/decidim/comments/comment/show.erb
+++ b/app/cells/decidim/comments/comment/show.erb
@@ -1,0 +1,44 @@
+<%= content_tag :div, id: "comment_#{model.id}", class: comment_classes, data: { comment_id: model.id } do %>
+  <div class="comment__header">
+    <div class="author-data">
+      <div class="author-data__main">
+        <%= render :author %>
+        <span>
+          <%= time_tag created_at, l(created_at, format: :decidim_short) %>
+        </span>
+      </div>
+      <div class="author-data__extra">
+        <%= render :utilities %>
+      </div>
+    </div>
+  </div>
+  <div class="comment__content">
+    <%= alignment_badge %>
+    <%= comment_body %>
+
+    <% if translatable? %>
+      <%= translate_button_helper_for(title: "", body: comment_body, model: model) %>
+    <% end %>
+  </div>
+  <div class="comment__footer">
+    <%= render :actions %>
+    <%= votes %>
+  </div>
+  <div id="comment-<%= model.id %>-replies">
+    <% if has_replies? %>
+      <% replies.each do |reply| %>
+        <%=cell("decidim/comments/comment", reply, root_depth: root_depth, order: order) %>
+      <% end %>
+    <% end %>
+  </div>
+  <% if can_reply? %>
+    <div class="comment__additionalreply<%= " hide" unless has_replies? %>">
+      <button class="comment__reply muted-link" aria-controls="<%= reply_id %>" data-toggle="<%= reply_id %>">
+        <%= icon "pencil", class: "icon--small", role: "none presentation" %>&nbsp;<%= t("decidim.components.comment.reply") %>
+      </button>
+    </div>
+    <div class="add-comment hide" id="<%= reply_id %>" data-toggler=".hide">
+      <%== cell("decidim/comments/comment_form", model, root_depth: root_depth, order: order) %>
+    </div>
+  <% end %>
+<% end %>

--- a/lib/extends/decidim-comments/lib/decidim/comments/comments_helper.rb
+++ b/lib/extends/decidim-comments/lib/decidim/comments/comments_helper.rb
@@ -6,6 +6,8 @@ module CommentsHelperExtend
   extend ActiveSupport::Concern
 
   included do
+    delegate :current_locale, to: :controller
+
     def translatable?
       @organization ||= try(:current_organization)
       @organization ||= try(:current_participatory_space).try(:organization)
@@ -17,3 +19,5 @@ module CommentsHelperExtend
 end
 
 Decidim::Comments::CommentsHelper.send(:include, CommentsHelperExtend)
+Decidim::Comments::CommentCell.send(:include, Decidim::Comments::CommentsHelper)
+Decidim::Comments::CommentCell.send(:include, Decidim::DeeplHelper)


### PR DESCRIPTION
Updated:

* Moved back option to translate comments when organization has setup for
deepl API.

* fixed issue with making HTTP call via Net::HTTP. The http_logger gem
  used monkey patching which is not properly working for latest rubies.