### PR TITLE
BOSA21Q1-131 & BOSA21Q1-356 democratie.brussels : signature gauge in several parts

### DIFF
--- a/app/cells/decidim/progress_bar/show.erb
+++ b/app/cells/decidim/progress_bar/show.erb
@@ -2,8 +2,8 @@
   <div class="progress__bar__title">
 
     <% if horizontal? %>
+      <span class="progress__bar__number"><%= number_with_delimiter(progress, delimiter: t(".number_delimiter")) %></span>
       <span class="progress__bar__text"><%= subtitle_text %></span>
-      <span class="progress__bar__number"><%= number_with_delimiter(progress, delimiter: t(".number_delimiter")) %></span><%= "/#{number_with_delimiter(total, delimiter: t(".number_delimiter"))}" if total != 0 %>
     <% else %>
       <span class="progress__bar__number"><%= number_with_delimiter(progress, delimiter: t(".number_delimiter")) %></span><%= "/#{number_with_delimiter(total, delimiter: t(".number_delimiter"))}" if total != 0 %>
       <span class="progress__bar__text"><%= units_name_text %></span>

--- a/app/models/decidim/initiative.rb
+++ b/app/models/decidim/initiative.rb
@@ -379,9 +379,9 @@ module Decidim
     end
 
     def set_offline_votes_total
-      return if offline_votes.blank? || scope.nil?
+      self.offline_votes = {"total": 0} if offline_votes.blank?
 
-      offline_votes["total"] = offline_votes[scope.id.to_s]
+      self.offline_votes.merge!({"total": offline_votes.except('total').values.sum(&:to_i)})
     end
 
     # Public: Finds all the InitiativeTypeScopes that are eligible to be voted by a user.
@@ -437,7 +437,7 @@ module Decidim
     end
 
     def accepts_offline_votes?
-      published? && (offline_signature_type? || any_signature_type?)
+      published? && votes_enabled? && (offline_signature_type? || any_signature_type?)
     end
 
     def accepts_online_votes?

--- a/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
+++ b/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
@@ -116,7 +116,7 @@
         <div class="columns xlarge-6">
           <% @form.offline_votes.each do |scope_id, (votes, scope_name)| %>
             <%= label_tag "initiative_offline_votes_#{scope_id}", t("activemodel.attributes.initiative.offline_votes_for_scope", scope_name: translated_attribute(scope_name)) %>
-            <%= number_field_tag "initiative[offline_votes][#{scope_id}][]", votes, min: 0, id: "initiative_offline_votes_#{scope_id}" %>
+            <%= number_field_tag "initiative[offline_votes][#{scope_id}]", votes, min: 0, id: "initiative_offline_votes_#{scope_id}" %>
           <% end %>
         </div>
       </div>

--- a/app/views/decidim/initiatives/initiatives/_progress_bar.html.erb
+++ b/app/views/decidim/initiatives/initiatives/_progress_bar.html.erb
@@ -2,27 +2,44 @@
   <p><%= t(".no_signature_explanation") %></p>
 <% else %>
   <div id="initiative-<%= current_initiative.id %>-progress-bar" class="vote-cabin-progress-bar">
-    <% current_initiative.votable_initiative_type_scopes.each_with_index do |type_scope, index| %>
-      <% if type_scope.global_scope? %>
-        <%= cell(
-                "decidim/progress_bar",
-                current_initiative.online_votes_count,
-                # current_initiative.online_votes_count_for(type_scope.scope),
-                total: type_scope.supports_required,
-                units_name: "decidim.initiatives.initiatives.votes_count.count",
-                element_id: "initiative-#{current_initiative.id}-votes-count",
-                subtitle_text: current_initiative.supports_goal_reached? ? t("decidim.initiatives.initiatives.votes_count.most_popular_initiative") : t("decidim.initiatives.initiatives.votes_count.need_more_votes"),
-                small: false
-            ) %>
-      <% else %>
-        <%= cell(
-                "decidim/progress_bar",
-                current_initiative.online_votes_count_for(type_scope.scope),
-                total: type_scope.supports_required,
-                subtitle_text: translated_attribute(type_scope.scope_name),
-                element_id: "initiative-scope-#{type_scope.id}-#{current_initiative.id}-votes-count",
-                horizontal: true
-            ) %>
+
+    <%= cell(
+            "decidim/progress_bar",
+            current_initiative.supports_count,
+            total: current_initiative.supports_required,
+            units_name: "decidim.initiatives.initiatives.votes_count.total_count",
+            element_id: "initiative-#{current_initiative.id}-votes-total-count",
+            subtitle_text: current_initiative.supports_goal_reached? ? t("decidim.initiatives.initiatives.votes_count.most_popular_initiative") : t("decidim.initiatives.initiatives.votes_count.need_more_votes"),
+            small: false
+        ) %>
+
+    <% if current_initiative.votable_initiative_type_scopes.count > 1 %>
+      <% accepts_online_and_offline_votes = current_initiative.accepts_online_votes? && current_initiative.accepts_offline_votes? %>
+      <% current_initiative.votable_initiative_type_scopes.each_with_index do |type_scope, index| %>
+        <% if current_initiative.accepts_online_votes? %>
+          <%= cell(
+                  "decidim/progress_bar",
+                  current_initiative.online_votes_count_for(type_scope.scope),
+                  total: type_scope.supports_required,
+                  subtitle_text: accepts_online_and_offline_votes ?
+                                     t("activemodel.attributes.initiative.online_votes_for_scope", scope_name: translated_attribute(type_scope.scope_name))
+                                     : translated_attribute(type_scope.scope_name),
+                  element_id: "initiative-scope-#{type_scope.id}-#{current_initiative.id}-votes-count",
+                  horizontal: true
+              ) %>
+        <% end %>
+        <% if current_initiative.accepts_offline_votes? %>
+          <%= cell(
+                  "decidim/progress_bar",
+                  current_initiative.offline_votes_count_for(type_scope.scope),
+                  total: type_scope.supports_required,
+                  subtitle_text: accepts_online_and_offline_votes ?
+                                     t("activemodel.attributes.initiative.offline_votes_for_scope", scope_name: translated_attribute(type_scope.scope_name))
+                                     : translated_attribute(type_scope.scope_name),
+                  element_id: "initiative-scope-#{type_scope.id}-#{current_initiative.id}-votes-count",
+                  horizontal: true
+              ) %>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/config/locales/decidim-initiatives/en.yml
+++ b/config/locales/decidim-initiatives/en.yml
@@ -5,6 +5,7 @@ en:
       initiative:
         area_ids: Areas
         offline_votes_for_scope: In-person signatures for %{scope_name}
+        online_votes_for_scope: Online signatures for %{scope_name}
 
       initiatives_type:
         #area_enabled: Enable authors to choose the area for their initiative
@@ -181,6 +182,10 @@ en:
           version: Version %{number}
         vote_button:
           cannot_accumulate_supports_beyond_threshold: The required amount of votes has been reached
+        votes_count:
+          total_count:
+            one: TOTAL SIGNATURE
+            other: TOTAL SIGNATURES
         organization_initiatives_settings:
           create:
             modal_title: Sorry, you are not allowed to perfom this action

--- a/config/locales/decidim-initiatives/fr.yml
+++ b/config/locales/decidim-initiatives/fr.yml
@@ -14,6 +14,7 @@ fr:
         description: Description
         offline_votes: Votes en présentiel
         offline_votes_for_scope: Signatures en présentiel pour %{scope_name}
+        online_votes_for_scope: Signatures en ligne pour %{scope_name}
         scope_id: Périmètre d'application
         signature_end_date: Fin de la période de collecte des signatures
         signature_start_date: Début de la période de collecte des signatures
@@ -648,6 +649,9 @@ fr:
         vote_button:
           cannot_accumulate_supports_beyond_threshold: Le nombre de votes requis est atteint
         votes_count:
+          total_count:
+            one: TOTAL SIGNATURE
+            other: TOTAL SIGNATURES
           count:
             one: SIGNATURE
             other: SIGNATURES

--- a/config/locales/decidim-initiatives/nl.yml
+++ b/config/locales/decidim-initiatives/nl.yml
@@ -10,6 +10,7 @@ nl:
         description: Beschrijving
         offline_votes: Face-to-face handtekeningen
         offline_votes_for_scope: In-person signatures for %{scope_name}
+        online_votes_for_scope: Online signatures for %{scope_name}
         scope_id: Bereik
         signature_end_date: Einde van de periode om handtekeningen te verzamelen
         signature_start_date: Begin van de periode voor het verzamelen van handtekeningen
@@ -490,6 +491,9 @@ nl:
         vote_button:
           cannot_accumulate_supports_beyond_threshold: Het vereiste aantal stemmen is bereikt
         votes_count:
+          total_count:
+            one: TOTALE HANDTEKENING
+            other: TOTAAL HANDTEKENINGEN
           count:
             one: HANDTEKENING
             other: HANDTEKENINGEN

--- a/lib/extends/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_form.rb
+++ b/lib/extends/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_form.rb
@@ -31,7 +31,7 @@ module AdminInitiativeFormExtend
       self.decidim_scope_id = model.scope&.id
       self.offline_votes = model.offline_votes
 
-      if offline_votes.empty?
+      if (offline_votes || {}).except("total").empty?
         self.offline_votes = model.votable_initiative_type_scopes.each_with_object({}) do |initiative_scope_type, all_votes|
           all_votes[initiative_scope_type.decidim_scopes_id || "global"] = [0, initiative_scope_type.scope_name]
         end


### PR DESCRIPTION
**What? Why?**
Currently on UI (in front office) we see only online signatures. 
This change adds sub-gauge to display separately the digital signatures and in-person (paper) signatures.
There are also a few fixes to properly handle and update the offline votes count that admin can set for an initiative in admin panel.

**Tickets:**
BOSA21Q1-131 democratie.brussels : signature gauge in several parts
BOSA21Q1-356 democratie.brussels : digital + paper signatures
