### PR TITLE
BOSA21Q1-333 De Kamer: confirmation e-mail in FR instead of NL

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GIT
 
 GIT
   remote: https://github.com/belighted/decidim-module-verifications_omniauth
-  revision: 94741de7cb891d11bf45bb6fb3440b7012460d1c
+  revision: bf47e9e0c21db0453418dcecce7dde25e0678d7e
   branch: 0.22.0
   specs:
     decidim-verifications_omniauth (0.22.0)


### PR DESCRIPTION
**What? Why?**
The user locale is not set when user create his account using CSAM login. It works properly when creating an account using email+pass flow.

**PR in modules:**
https://github.com/belighted/decidim-module-verifications_omniauth/pull/12