### PR TITLE
BOSA21Q1-408: add appsignal integration for puma

### DIFF
--- a/config/initializers/appsignal.rb
+++ b/config/initializers/appsignal.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Appsignal::Minutely.probes.register :web_app_probe, lambda {
+  Appsignal.set_gauge("database_size", 10)
+}

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -46,3 +46,7 @@ end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+# add integration for appsignal
+plugin :appsignal
+extra_runtime_dependencies ["appsignal"]


### PR DESCRIPTION
Updated:

Added appsignal plugin for puma to collect additional stats in our
monitoring utils.