### PR TITLE
BOSA21Q1-357: fix displaying list with links

### DIFF
--- a/app/assets/stylesheets/decidim/extends/_external-link.scss
+++ b/app/assets/stylesheets/decidim/extends/_external-link.scss
@@ -1,0 +1,7 @@
+.section, .static__content {
+  ul, ol {
+    .external-link-container {
+      display: inline;
+    }
+  }
+}


### PR DESCRIPTION
Updated:

The list which contains the link with long text is not properly
displayed. This is caused by displaying external-link-container in block
mode in the section or static__content cases. Changing display mode to
inline is fixing this issue. This will fix the case for suggestions, processes, initiatives and static-pages.

![Zrzut ekranu 2021-06-23 o 12 12 08](https://user-images.githubusercontent.com/409490/123079457-4105bd00-d41c-11eb-8bb0-9bd79493ddf2.png)