### PR TITLE
BOSA21Q1-301: nginx.conf: add a dummy location

### DIFF
--- a/ops/release/assets/nginx.conf
+++ b/ops/release/assets/nginx.conf
@@ -12,6 +12,11 @@ server {
   gzip_types  text/plain text/css text/javascript application/x-javascript application/javascript text/xml application/xml image/svg+xml;
   gzip_vary on;
 
+  location /ping {
+    access_log off;
+    return 200;
+  }
+
   location /assets/ {
     root   /app/public;
     index  index.html index.htm;


### PR DESCRIPTION
Benchmarking the infra (and not the rails app) is interesting so we add
a route only handled by nginx.