### PR TITLE
BOSA21Q1-230: nginx misconfiguration

### DIFF
--- a/ops/release/assets/nginx.conf
+++ b/ops/release/assets/nginx.conf
@@ -22,6 +22,11 @@ server {
     index  index.html index.htm;
   }
 
+  location ~ ^(?!/rails/).+\.(jpg|jpeg|gif|png|ico|json|txt|xml)$ {
+    root   /app/public;
+    index  index.html index.htm;
+  }
+
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;


### PR DESCRIPTION
On production, /robots.txt triggers an internal error. The reason is
that nginx only serves files in the assets directory, while robots.txt
is directly on the public one. As static file serving is disabled in
production, the files directly in public aren't available.

/public/robots.txt
/public/assets/*

Add a rule to serve static files even if they are from the root
directory. This rule is shamelessly taken from [0]

[0] https://acuments.com/rails-serve-static-files-with-nginx.html