### PR TITLE
ops: BOSA21Q1-230: bosa-assets doesn't serve the whole public dir

### DIFF
--- a/ops/release/assets/Dockerfile
+++ b/ops/release/assets/Dockerfile
@@ -1,8 +1,8 @@
 FROM nginx:stable-alpine
 LABEL maintainer="Dominique Lebrun <dominique.lebrun@belighted.com>"
 
-RUN mkdir -p /app/public/assets
-WORKDIR /app/public/assets
+RUN mkdir -p /app/public
+WORKDIR /app/public
 
-ADD ./public/assets /app/public/assets
+ADD ./public /app/public
 ADD ./ops/release/assets/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This is  a followup of 05e31696e7681bf59a328bdcfe4a04f7b02203f6

Accessing /robots.txt in uat doesn't trigger an internal server error
anymore, but a 404. The expected result was to display the robots.txt
file. By checking the nginx log, we know that this file was actually not
found on the server. By connecting on the server, we saw the only the
file was missing on the server, only the subdirectory "assets" was
found.

It due to how the image is built, where we made available only the
assets directory and not the whole public one.