### PR TITLE
BOSA21Q1-418 De Kamer: petition "answered" but shouldn't be

### DIFF
--- a/app/models/decidim/initiative.rb
+++ b/app/models/decidim/initiative.rb
@@ -85,8 +85,7 @@ module Decidim
         .or(where("signature_end_date < ?", Date.current))
     }
 
-    # scope :answered, -> { where.not(answered_at: nil) }
-    scope :answered, -> {where.not(answered_at: nil).or(where.not(answer_date: nil))}
+    scope :answered, -> { where.not(answered_at: nil) }
     scope :published, -> { where.not(published_at: nil) }
 
     scope :public_spaces, -> { published }

--- a/lib/extends/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_answer.rb
+++ b/lib/extends/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_answer.rb
@@ -16,7 +16,7 @@ module UpdateInitiativeAnswerExtend
         answer_date: answer_date
       }
 
-      attrs[:answered_at] = Time.current if form.answer.present?
+      attrs[:answered_at] = form.answer.blank? || form.answer.values.all?(&:blank?) ? nil : Time.current
 
       if form.signature_dates_required?
         attrs[:signature_start_date] = form.signature_start_date


### PR DESCRIPTION
Clear answered_at when answer is blank, bring back standard scope for filters