### PR TITLE
BOSA21Q1-505 Interactive map module shouldn't register itself as a component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/belighted/decidim-module-homepage_interactive_map
-  revision: 731499fcde1c1402814ee5d5b7ee24e3362b7608
+  revision: 7dc5d5c9adc978151bcf5207d9879c599f63a11a
   branch: 0.22.0
   specs:
     decidim-homepage_interactive_map (0.22.0)


### PR DESCRIPTION
Changes in module: https://github.com/belighted/decidim-module-homepage_interactive_map/commit/7dc5d5c9adc978151bcf5207d9879c599f63a11a