### PR TITLE
BOSA21Q1-507: `CalculateAllMetrics` daily job outside of business hours

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,7 +9,7 @@
 
 :schedule:
   CalculateAllMetrics:
-    cron: '0 14 * * *'
+    cron: '0 22 * * *'
     class: CalculateAllMetricsJob
   PreloadOpenData:
     cron: '0 17 * * *'


### PR DESCRIPTION
This task is currently ran at 14h.

It uses 20 times the number of postgres transactions than the usual load
during the day. We move this task later in the day so in order to not
impact normal users.

This task was first ran at 17h05 then was changed in [0] for no apparent
nor explained reasons.

[0] 1b134585220a7fcfae7ebfa90e3bfa7fc48e7810