### PR TITLE
BOSA21Q1-509 Allow to unlink participatory processes from an assembly

### DIFF
--- a/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -212,7 +212,7 @@
                             @form.processes_for_select,
                             selected: processes_selected
                           ),
-                        { include_blank: false },
+                        { include_blank: true },
                         { multiple: true, class: "chosen-select" } %>
       <% end %>
     </div>


### PR DESCRIPTION
Without the blank option in the select element there was no option to clear/unlink previously selected participatory processes from an assembly. Blank option allows to remove previously made relations.