### PR TITLE
BOSA21Q1-217 Bosa & Bosa cities: slugs of pages > add validations

### DIFF
--- a/lib/extends/decidim-admin/app/forms/decidim/admin/static_page_form.rb
+++ b/lib/extends/decidim-admin/app/forms/decidim/admin/static_page_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module StaticPageFormExtend
+  extend ActiveSupport::Concern
+
+  included do
+
+    validates :slug, format: {with: %r{\A[a-zA-Z]+[a-zA-Z0-9\-\_]+\z}}, allow_blank: true
+
+  end
+end
+
+Decidim::Admin::StaticPageForm.send(:include, StaticPageFormExtend)


### PR DESCRIPTION
Remove `/` from list of allowed chars as it breaks the URL navigation and static page became broken to edit.