### PR TITLE
BOSA21Q1-217: nginx + admin pages with html escaped characters

### DIFF
--- a/ops/release/assets/nginx.conf
+++ b/ops/release/assets/nginx.conf
@@ -45,6 +45,23 @@ server {
       proxy_pass http://127.0.0.1:3000/pages/$uri/;
   }
 
+  location /admin/static_pages/ {
+      rewrite ^ $request_uri;           # replace $uri by its raw value, without nginx's transformations
+      rewrite ^/admin/static_pages/(.*) $1 break;    # get the group containing the page name
+      return 400;                       # return early if the group is empty
+      # pass the group http://127.0.0.1:3000/admin/static_pages/
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+      proxy_read_timeout 300s;
+      proxy_send_timeout 300s;
+      proxy_set_header  X-Forwarded-Proto https;
+      proxy_set_header  X-Forwarded-Ssl on; # Optional
+      proxy_set_header  X-Forwarded-Port 443;
+      proxy_set_header  X-Forwarded-Host $host;
+      proxy_pass http://127.0.0.1:3000/admin/static_pages/$uri/;
+  }
+
   location ~ ^(?!/rails/).+\.(jpg|jpeg|gif|png|ico|json|txt|xml)$ {
     root   /app/public;
     index  index.html index.htm;


### PR DESCRIPTION
this is the exact same fix as [0] but related to an admin page

[0] 535fab681c2e0892828114e6c01aa4e03ef84e4f