### PR TITLE
BOSA21Q1-217: nginx + pages and admin pages with html escaped characters

### DIFF
--- a/ops/release/assets/nginx.conf
+++ b/ops/release/assets/nginx.conf
@@ -28,7 +28,7 @@ server {
   # we disable this behavior for this route
   # https://trac.nginx.org/nginx/ticket/727
   # https://stackoverflow.com/questions/28684300/nginx-pass-proxy-subdirectory-without-url-decoding/37584637#37584637
-  location /pages/ {
+  location ~ "^/pages/(.{1,})$" {
       rewrite ^ $request_uri;           # replace $uri by its raw value, without nginx's transformations
       rewrite ^/pages/(.*) $1 break;    # get the group containing the page name
       return 400;                       # return early if the group is empty
@@ -45,7 +45,7 @@ server {
       proxy_pass http://127.0.0.1:3000/pages/$uri/;
   }
 
-  location /admin/static_pages/ {
+  location ~ "^/admin/static_pages/(.{1,})$" {
       rewrite ^ $request_uri;           # replace $uri by its raw value, without nginx's transformations
       rewrite ^/admin/static_pages/(.*) $1 break;    # get the group containing the page name
       return 400;                       # return early if the group is empty


### PR DESCRIPTION
previous attempts [0][1] were incomplete because they forgot that urls
like /pages and /admin/static_pages (i.e., without any subpage) should
not go through the disabled unescape thingy but be routed the normal
way. Else, we get an error, because the subgroup is empty.

[0] 535fab681c2e0892828114e6c01aa4e03ef84e4f
[1] abc1940ec4857c1e5e7ca8dc38955b98ec830b21