### PR TITLE
BOSA21Q1-217: nginx + pages and admin pages with html escaped characters

### DIFF
--- a/ops/release/assets/nginx.conf
+++ b/ops/release/assets/nginx.conf
@@ -42,7 +42,7 @@ server {
       proxy_set_header  X-Forwarded-Ssl on; # Optional
       proxy_set_header  X-Forwarded-Port 443;
       proxy_set_header  X-Forwarded-Host $host;
-      proxy_pass http://127.0.0.1:3000/pages/$uri/;
+      proxy_pass http://127.0.0.1:3000/pages/$uri;
   }
 
   location ~ "^/admin/static_pages/(.{1,})$" {
@@ -59,7 +59,7 @@ server {
       proxy_set_header  X-Forwarded-Ssl on; # Optional
       proxy_set_header  X-Forwarded-Port 443;
       proxy_set_header  X-Forwarded-Host $host;
-      proxy_pass http://127.0.0.1:3000/admin/static_pages/$uri/;
+      proxy_pass http://127.0.0.1:3000/admin/static_pages/$uri;
   }
 
   location ~ ^(?!/rails/).+\.(jpg|jpeg|gif|png|ico|json|txt|xml)$ {


### PR DESCRIPTION
revisions [0][1][2] displayed another shortcoming: translations didn't
work anymore on the /pages/xx and /admin/static_pages/xx and editing a
static page in another language triggered a server error.

This is due to the redirection adding a trailing /

?locale=fr was rewritten as ?local=fr/, resulting in a not found
language.

[0] 535fab681c2e0892828114e6c01aa4e03ef84e4f
[1] abc1940ec4857c1e5e7ca8dc38955b98ec830b21
[2] 6de474ee577cebd5eea1147cb96ec71537e1532b