### PR TITLE
BOSA21Q1-561 Fix Quill editor issue displaying all lists as ordered lists

### DIFF
--- a/app/assets/stylesheets/decidim/editor.scss
+++ b/app/assets/stylesheets/decidim/editor.scss
@@ -1,0 +1,25 @@
+//@import "quill.snow";
+@import "quill-plugins/2.0.0-dev.3-quill.snow.min";
+
+@import "decidim/variables";
+@import "decidim/utils/settings";
+
+.editor-container{
+  margin-bottom: 1.5rem;
+
+  p{
+    line-height: $paragraph-lineheight;
+    margin-bottom: $paragraph-margin-bottom;
+    text-rendering: $paragraph-text-rendering;
+  }
+}
+
+// Set disc style for bullet list items when displaying html produced by quill editor
+// quill-2.0.0-dev.3 stores all lists as OL lists + `data-list` attribute
+ol > li[data-list=bullet] {
+  list-style-type: disc;
+}
+// Don't set it for the editor itself as there is no issues in displaying ordered/bullet lists
+.ql-editor ol > li[data-list=bullet] {
+  list-style-type: none;
+}

--- a/lib/extends/decidim-core/app/scrubbers/decidim/user_input_scrubber.rb
+++ b/lib/extends/decidim-core/app/scrubbers/decidim/user_input_scrubber.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module UserInputScrubberExtend
+  extend ActiveSupport::Concern
+
+  included do
+
+    private
+
+    def custom_allowed_attributes
+      # Add `data-list` attribute to handle quill-2.0.0-dev.3 issue with OL/UL lists
+      Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES + %w(frameborder allowfullscreen) + %w(data-list)
+    end
+
+  end
+end
+
+Decidim::UserInputScrubber.send(:include, UserInputScrubberExtend)


### PR DESCRIPTION
Fix issue displaying OL/UL lists produced by quill editor.

**Problem**: Quill 2.0 stores all lists as OL lists + `data-list` attribute having `ordered` or `bullet` value. We do use html produced by Quill and given all lists are saved as `<ol>` tags they're always displayed as ordered lists even when they were created in editor as bullet lists.
**Reference**: https://github.com/quilljs/quill/issues/3014

**Solution**: To avoid changes via JS for quill (by custom plugin for UL list) the fix is done by CSS only:
- allow `data-list` attribute in Decidim sanitizer
- add custom css to override `list-style-type` for bullet lists

---
Additional minor issue fixed:
```
//@import "quill.snow";
@import "quill-plugins/2.0.0-dev.3-quill.snow.min";
```
Replace quill css from standard quill-1.3 to 2.0.0-dev.3, the only noticed issue was that in the editor for UL lists the list-style-type was displayed with both number and bullet.