### PR TITLE
BOSA21Q1-634 Set default reply_to based on organization settings

### DIFF
--- a/lib/extends/decidim-core/app/mailers/decidim/application_mailer.rb
+++ b/lib/extends/decidim-core/app/mailers/decidim/application_mailer.rb
@@ -6,7 +6,21 @@ module ApplicationMailerExtend
   extend ActiveSupport::Concern
 
   included do
-    default reply_to: Decidim.config.mailer_reply || Decidim.config.mailer_sender
+
+    private
+
+    def set_smtp
+      return if @organization.nil? || @organization.smtp_settings.blank?
+
+      mail.from = @organization.smtp_settings["from"].presence || mail.from
+      mail.reply_to = mail.reply_to || @organization.smtp_settings["from_email"].presence || Decidim.config.mailer_reply
+      mail.delivery_method.settings.merge!(
+        address: @organization.smtp_settings["address"],
+        port: @organization.smtp_settings["port"],
+        user_name: @organization.smtp_settings["user_name"],
+        password: Decidim::AttributeEncryptor.decrypt(@organization.smtp_settings["encrypted_password"])
+      ) { |_k, o, v| v.presence || o }.reject! { |_k, v| v.blank? }
+    end
   end
 end
 


### PR DESCRIPTION
Fixes reply/receiver email on NAPAN and Anderlecht

The only change is a new line added:
`mail.reply_to = @organization.smtp_settings["from_email"].presence || mail.reply_to`