### PR TITLE
BOSA21Q1-638 NAPAN Notifications bell not working

### DIFF
--- a/lib/extends/decidim-proposals/app/events/decidim/proposals/admin/proposal_note_created_event.rb
+++ b/lib/extends/decidim-proposals/app/events/decidim/proposals/admin/proposal_note_created_event.rb
@@ -1,0 +1,18 @@
+# frozen-string_literal: true
+
+require "active_support/concern"
+
+module AdminProposalNoteCreatedEventExtend
+  extend ActiveSupport::Concern
+
+  included do
+
+    def admin_proposal_info_url
+      # decidim_admin_participatory_process_proposals.proposal_url(resource, resource.component.mounted_params)
+      send(resource.component.mounted_admin_engine).proposal_url(resource, resource.component.mounted_params)
+    end
+
+  end
+end
+
+Decidim::Proposals::Admin::ProposalNoteCreatedEvent.send(:include, AdminProposalNoteCreatedEventExtend)


### PR DESCRIPTION
Fixes exception generating of proposal_url for an event notification when proposal related to anything else except participatory process