### PR TITLE
BOSA21Q1-674 Crons not working

### DIFF
--- a/app/jobs/calculate_all_metrics_job.rb
+++ b/app/jobs/calculate_all_metrics_job.rb
@@ -2,9 +2,8 @@
 
 class CalculateAllMetricsJob < ApplicationJob
   def perform
-    application_name = Rails.application.class.parent_name
-    application = Object.const_get(application_name)
-    application::Application.load_tasks
+    DecidimAws::Application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task["decidim:metrics:all"].reenable
     Rake::Task["decidim:metrics:all"].invoke
   end
 end

--- a/app/jobs/check_published_initiatives.rb
+++ b/app/jobs/check_published_initiatives.rb
@@ -2,7 +2,7 @@
 
 class CheckPublishedInitiatives < ApplicationJob
   def perform
-    DecidimAws::Application.load_tasks
+    DecidimAws::Application.load_tasks if Rake::Task.tasks.empty?
     Rake::Task["decidim_initiatives:check_published"].clear
 
     load Rails.root.join('lib', 'tasks', 'decidim_initiatives_extras.rake')

--- a/app/jobs/check_published_suggestions.rb
+++ b/app/jobs/check_published_suggestions.rb
@@ -2,9 +2,8 @@
 
 class CheckPublishedSuggestions < ApplicationJob
   def perform
-    application_name = Rails.application.class.parent_name
-    application = Object.const_get(application_name)
-    application::Application.load_tasks
+    DecidimAws::Application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task["decidim_suggestions:check_published"].reenable
     Rake::Task["decidim_suggestions:check_published"].invoke
   end
 end

--- a/app/jobs/check_validating_initiatives.rb
+++ b/app/jobs/check_validating_initiatives.rb
@@ -2,9 +2,8 @@
 
 class CheckValidatingInitiatives < ApplicationJob
   def perform
-    application_name = Rails.application.class.parent_name
-    application = Object.const_get(application_name)
-    application::Application.load_tasks
+    DecidimAws::Application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task["decidim_initiatives:check_validating"].reenable
     Rake::Task["decidim_initiatives:check_validating"].invoke
   end
 end

--- a/app/jobs/check_validating_suggestions.rb
+++ b/app/jobs/check_validating_suggestions.rb
@@ -2,9 +2,8 @@
 
 class CheckValidatingSuggestions < ApplicationJob
   def perform
-    application_name = Rails.application.class.parent_name
-    application = Object.const_get(application_name)
-    application::Application.load_tasks
+    DecidimAws::Application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task["decidim_suggestions:check_validating"].reenable
     Rake::Task["decidim_suggestions:check_validating"].invoke
   end
 end

--- a/app/jobs/clean_sessions.rb
+++ b/app/jobs/clean_sessions.rb
@@ -2,7 +2,8 @@
 
 class CleanSessions < ApplicationJob
   def perform
-    DecidimAws::Application.load_tasks
+    DecidimAws::Application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task['db:sessions:trim'].reenable
     Rake::Task['db:sessions:trim'].invoke
   end
 end

--- a/app/jobs/clean_sign_in_ips.rb
+++ b/app/jobs/clean_sign_in_ips.rb
@@ -2,7 +2,8 @@
 
 class CleanSignInIps < ApplicationJob
   def perform
-    DecidimAws::Application.load_tasks
+    DecidimAws::Application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task['users:clean_sign_in_ips'].reenable
     Rake::Task['users:clean_sign_in_ips'].invoke
   end
 end

--- a/app/jobs/notify_progress_initiatives.rb
+++ b/app/jobs/notify_progress_initiatives.rb
@@ -2,9 +2,8 @@
 
 class NotifyProgressInitiatives < ApplicationJob
   def perform
-    application_name = Rails.application.class.parent_name
-    application = Object.const_get(application_name)
-    application::Application.load_tasks
+    DecidimAws::Application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task["decidim_initiatives:notify_progress"].reenable
     Rake::Task["decidim_initiatives:notify_progress"].invoke
   end
 end

--- a/app/jobs/notify_progress_suggestions.rb
+++ b/app/jobs/notify_progress_suggestions.rb
@@ -2,9 +2,8 @@
 
 class NotifyProgressSuggestions < ApplicationJob
   def perform
-    application_name = Rails.application.class.parent_name
-    application = Object.const_get(application_name)
-    application::Application.load_tasks
+    DecidimAws::Application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task["decidim_suggestions:notify_progress"].reenable
     Rake::Task["decidim_suggestions:notify_progress"].invoke
   end
 end

--- a/app/jobs/preload_open_data_job.rb
+++ b/app/jobs/preload_open_data_job.rb
@@ -2,9 +2,8 @@
 
 class PreloadOpenDataJob < ApplicationJob
   def perform
-    application_name = Rails.application.class.parent_name
-    application = Object.const_get(application_name)
-    application::Application.load_tasks
+    DecidimAws::Application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task["decidim:open_data:export"].reenable
     Rake::Task["decidim:open_data:export"].invoke
   end
 end


### PR DESCRIPTION
Fix issue with cron jobs when they were executed properly but the code inside (a rake task) wasn't.
Update 'load_tasks' execution to prevent potential multiple initialization of the same rake task.

1. Issue executing rake tasks.
As docs (https://ruby-doc.org/stdlib-2.0.0/libdoc/rake/rdoc/Rake/Task.html#method-i-invoke) says the `invoke` is "Invoke the task if it is needed. Prerequisites are invoked first."
So it only executes the task if it has not already been invoked.
```
> Rake::Task['db:sessions:trim'].invoke
  ActiveRecord::SessionStore::Session Destroy (2.8ms)  DELETE FROM "sessions" WHERE (updated_at < '2022-02-14 12:18:33.670409')
=> [#<Proc:0x000055808a04f0a0@/home/sergei-krylov/.rvm/gems/ruby-2.6.6@bosa/gems/activerecord-session_store-2.0.0/lib/tasks/database.rake:15>]
> Rake::Task['db:sessions:trim'].invoke
=> nil
> Rake::Task['db:sessions:trim'].invoke
=> nil
```
The fix is to call `reenable` first, which is "Reenable the task, allowing its tasks to be executed if the task is invoked again.".

2. Prevent (potentially) load the same task(s) multiple times.
The `DecidimAws::Application.load_tasks` is required to load rake tasks to execute them.
```
> Rake::Task['db:sessions:trim'].invoke
RuntimeError: Don't know how to build task 'db:sessions:trim' (See the list of available tasks with `rake --tasks`)
> Rake::Task.tasks
=> []
> DecidimAws::Application.load_tasks; true
=> true
> Rake::Task['db:sessions:trim'].invoke
ActiveRecord::SessionStore::Session Destroy (0.5ms)  DELETE FROM "sessions" WHERE (updated_at < '2022-02-14 12:34:24.823680')
=> [#<Proc:0x000055958e8317c8@/home/sergei-krylov/.rvm/gems/ruby-2.6.6@bosa/gems/activerecord-session_store-2.0.0/lib/tasks/database.rake:15>]
```

Calling `DecidimAws::Application.load_tasks` multiple times in the same session leads to multiple definitions of the same task and multiple executions of it when task is called:
```
> DecidimAws::Application.load_tasks; true
=> true
> DecidimAws::Application.load_tasks; true
=> true
> DecidimAws::Application.load_tasks; true
=> true
> Rake::Task['db:sessions:trim'].invoke
ActiveRecord::SessionStore::Session Destroy (0.8ms)  DELETE FROM "sessions" WHERE (updated_at < '2022-02-14 12:35:31.341423')
ActiveRecord::SessionStore::Session Destroy (0.3ms)  DELETE FROM "sessions" WHERE (updated_at < '2022-02-14 12:35:31.357110')
ActiveRecord::SessionStore::Session Destroy (0.3ms)  DELETE FROM "sessions" WHERE (updated_at < '2022-02-14 12:35:31.357798')
=> [#<Proc:0x000056082d70c250@/home/sergei-krylov/.rvm/gems/ruby-2.6.6@bosa/gems/activerecord-session_store-2.0.0/lib/tasks/database.rake:15>,
  #<Proc:0x000056082d9d1418@/home/sergei-krylov/.rvm/gems/ruby-2.6.6@bosa/gems/activerecord-session_store-2.0.0/lib/tasks/database.rake:15>,
  #<Proc:0x000056082daddf00@/home/sergei-krylov/.rvm/gems/ruby-2.6.6@bosa/gems/activerecord-session_store-2.0.0/lib/tasks/database.rake:15>]
```

The fix is to only load tasks if they haven't been loaded yet.