### PR TITLE
BOSA21Q1-716 Fix HTTP 500 querying non existing resource

### DIFF
--- a/lib/extends/decidim-core/app/controllers/decidim/user_activities_controller.rb
+++ b/lib/extends/decidim-core/app/controllers/decidim/user_activities_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module UserActivitiesControllerExtend
+  extend ActiveSupport::Concern
+
+  included do
+    def index
+      # From Decidim commit https://github.com/decidim/decidim/commit/d6671d458cbe6dda53514d07bed09e6cd9c8836f
+      raise ActionController::RoutingError, "Missing user: #{params[:nickname]}" unless user
+    end
+  end
+end
+
+Decidim::UserActivitiesController.send(:include, UserActivitiesControllerExtend)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,8 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 
 User-agent: *
+Disallow: /profiles/
+Disallow: /processes/*/*/*/results
 Disallow: /*/*/*/*/proposals/
 Disallow: /*.png$
 Disallow: /*/*/*/*/*/*/versions/


### PR DESCRIPTION
[BOSA21Q1-716](https://belighted.atlassian.net/browse/BOSA21Q1-716)

With Sentry and AppSignal we have noticed that bots try to access non existing resources which triggers HTTP 500, which itself triggers an alert in Sentry and AppSignal. These alerts are noise because when using navigation, an end-user can't reach these pages. Still the noise should be removed, those access should return HTTP 404 instead.

- [x] access to activity profile page on non existing user, [example](https://sentry.io/organizations/belighted/issues/3138005748/?environment=bosa-cities-production&project=5471760&query=is%3Aunresolved+title%3A%22ActionView%3A%3ATemplate%3A%3AError%3A+undefined+method+%60nickname%27+for+nil%3ANilClass%22&sort=freq&statsPeriod=14d). note: lots of users have been removed by a script on March 15th
- [x] access to non existing version of proposals, [example](https://sentry.io/organizations/belighted/issues/3140343720/?environment=bosa-cities-production&project=5471760&query=is%3Aunresolved+%21title%3A%22ActionView%3A%3ATemplate%3A%3AError%3A+undefined+method+%60nickname%27+for+nil%3ANilClass%22&sort=freq&statsPeriod=14d).