### PR TITLE
BOSA21Q1-721 Denial of page display in case of image comparison that takes too much server resource

### DIFF
--- a/app/views/decidim/accountability/versions/show.html.erb
+++ b/app/views/decidim/accountability/versions/show.html.erb
@@ -1,0 +1,26 @@
+<div class="row accountability">
+
+  <!--  1.5MB, roughly corresponds to 10sec. of page load time-->
+<% if current_version.object_changes && current_version.object_changes.length > 1_500_000 %>
+
+    <% Rails.logger.debug "Version display denied because comparing Base64 images consumes too much resources." %>
+    <%= t(".no_display") %>
+
+  <% else %>
+    <%= javascript_include_tag "diff.js" %>
+    <%= javascript_include_tag "decidim/accountability/accountability" %>
+
+    <div class="small-12 columns">
+      <%= render partial: "decidim/accountability/results/nav_breadcrumb", locals: { category: versioned_resource.parent.try(:category) || versioned_resource.try(:category) } %>
+    </div>
+    <%= cell(
+          "decidim/version",
+          current_version,
+          index: params[:id],
+          versioned_resource: versioned_resource,
+          versions_path: proc { url_for(action: :index) },
+          i18n_scope: "decidim.accountability.results.show.stats"
+        ) %>
+
+  <% end %>
+</div>

--- a/config/locales/decidim-accountability/en.yml
+++ b/config/locales/decidim-accountability/en.yml
@@ -1,0 +1,8 @@
+---
+en:
+  decidim:
+    accountability:
+      versions:
+        show:
+          no_display: This version comparison can't be displayed because it contains large images, we are working on a fix.
+

--- a/config/locales/decidim-accountability/fr.yml
+++ b/config/locales/decidim-accountability/fr.yml
@@ -1,0 +1,8 @@
+---
+fr:
+  decidim:
+    accountability:
+      versions:
+        show:
+          no_display: Cette comparaison de versions ne peut être affichée car elle contient de grandes images, on travaille sur une solution.
+

--- a/config/locales/decidim-accountability/nl.yml
+++ b/config/locales/decidim-accountability/nl.yml
@@ -1,0 +1,8 @@
+---
+nl:
+  decidim:
+    accountability:
+      versions:
+        show:
+          no_display: Deze versievergelijking kan niet worden weergegeven omdat deze grote afbeeldingen bevat, we werken aan een oplossing.
+


### PR DESCRIPTION
The first part of the review has been done in [this PR](https://github.com/belighted/bosa/pull/204).
We are still waiting for the validation of Bart for the rendering and the translations.

For summary:

- [BOSA21Q1-716](https://belighted.atlassian.net/browse/BOSA21Q1-716) is about all the HTTP 500 detected by AppSignal/Sentry, and may be partially/entirely solved by [BOSA21Q1-719](https://belighted.atlassian.net/browse/BOSA21Q1-719).

- [BOSA21Q1-719](https://belighted.atlassian.net/browse/BOSA21Q1-719) is about configuring robots.txt.

- [BOSA21Q1-721](https://belighted.atlassian.net/browse/BOSA21Q1-721) is for performance issue linked to image comparison.