### PR TITLE
BOSA21Q1-762 robots.txt - add the indexation of /proposals without query param filter

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,7 +3,7 @@
 User-agent: *
 Disallow: /profiles/
 Disallow: /processes/*/*/*/results
-Disallow: /*/*/*/*/proposals/
+Disallow: /*/*/*/*/proposals?*filter*
 Disallow: /*.png$
 Disallow: /*/*/*/*/*/*/versions/
 Disallow: /users/auth/csam


### PR DESCRIPTION
Ticket [BOSA21Q1-762](https://belighted.atlassian.net/browse/BOSA21Q1-762)
Solution from [Stackoverflow](https://stackoverflow.com/a/9149936/3790512)

The former line was added following ticket [BOSA21Q1-215](https://belighted.atlassian.net/browse/BOSA21Q1-215) and [this AppSignal incident](https://appsignal.com/belighted/sites/604fdfe25ac13f03e5858fff/exceptions/incidents/175).

Linked to https://github.com/belighted/bosa-cities/pull/104