### PR TITLE
BOSA21Q1-674 Crons not working

### DIFF
--- a/app/jobs/check_published_initiatives.rb
+++ b/app/jobs/check_published_initiatives.rb
@@ -6,6 +6,7 @@ class CheckPublishedInitiatives < ApplicationJob
     Rake::Task["decidim_initiatives:check_published"].clear
 
     load Rails.root.join('lib', 'tasks', 'decidim_initiatives_extras.rake')
+    Rake::Task['decidim_initiatives:check_published'].reenable
     Rake::Task['decidim_initiatives:check_published'].invoke
   end
 end


### PR DESCRIPTION
Related tickets: BOSA21Q1-818, BOSA21Q1-820

Same issue and fix as described in BOSA21Q1-674.
https://github.com/belighted/bosa/pull/198

The `.clear` call should remain in place to clear the "original" task initially added during decidim gem initialization, as we override that task.