### PR TITLE
BOSA21Q1-853 Add initiatives into open data export.

### DIFF
--- a/lib/extends/decidim-core/app/services/decidim/open_data_exporter.rb
+++ b/lib/extends/decidim-core/app/services/decidim/open_data_exporter.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module OpenDataExporterExtend
+  extend ActiveSupport::Concern
+
+  included do
+
+    FILE_NAME_PATTERN = "%{host}-open-data-%{entity}.csv"
+
+    private
+
+    def data
+      buffer = Zip::OutputStream.write_buffer do |out|
+        open_data_component_manifests.each do |manifest|
+          add_file_to_output(out, format(FILE_NAME_PATTERN, { host: organization.host, entity: manifest.name }), data_for_component(manifest))
+        end
+        open_data_participatory_space_manifests.each do |manifest|
+          add_file_to_output(out, format(FILE_NAME_PATTERN, { host: organization.host, entity: manifest.name }), data_for_participatory_space(manifest))
+        end
+      end
+
+      buffer.string
+    end
+
+    def data_for_component(export_manifest, col_sep = Decidim.default_csv_col_sep)
+      headers = []
+      collection = []
+      ActiveRecord::Base.uncached do
+        components.where(manifest_name: export_manifest.manifest.name).find_each do |component|
+          export_manifest.collection.call(component).find_in_batches(batch_size: 100) do |batch|
+            exporter = Decidim::Exporters::CSV.new(batch, export_manifest.serializer)
+            headers.push(*exporter.headers)
+            exported = exporter.export
+
+            tmpfile = Tempfile.new("#{export_manifest.name}-#{component.id}-")
+            tmpfile.write(exported.read)
+            # Do not delete the file when the reference is deleted
+            ObjectSpace.undefine_finalizer(tmpfile)
+            tmpfile.close
+
+            collection.push(tmpfile.path)
+          end
+        end
+      end
+
+      headers.uniq!
+
+      data = CSV.generate_line(headers, col_sep: col_sep)
+      collection.each do |content|
+        CSV.foreach(content, headers: true, col_sep: col_sep) do |row|
+          data << CSV.generate_line(row.values_at(*headers), col_sep: col_sep)
+        end
+        File.unlink(content)
+      end
+      Decidim::Exporters::ExportData.new(data, "csv")
+    end
+
+    def data_for_participatory_space(export_manifest)
+      collection = participatory_spaces.filter { |space| space.manifest.name == export_manifest.manifest.name }.flat_map do |participatory_space|
+        export_manifest.collection.call(participatory_space)
+      end
+
+      Decidim::Exporters::CSV.new(collection, export_manifest.serializer).export
+    end
+
+    def add_file_to_output(output, file_name, data)
+      output.put_next_entry(file_name)
+      output.write data.read
+    end
+
+    def open_data_component_manifests
+      @open_data_component_manifests ||= Decidim.component_manifests
+                                           .flat_map(&:export_manifests)
+                                           .select(&:include_in_open_data?)
+    end
+
+    def open_data_participatory_space_manifests
+      @open_data_participatory_space_manifests ||= Decidim.participatory_space_manifests
+                                                     .flat_map(&:export_manifests)
+                                                     .select(&:include_in_open_data?)
+    end
+
+    def components
+      @components ||= organization.published_components
+    end
+
+    def participatory_spaces
+      @participatory_spaces ||= organization.public_participatory_spaces
+    end
+
+  end
+end
+
+Decidim::OpenDataExporter.send(:include, OpenDataExporterExtend)

--- a/lib/extends/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/lib/extends/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -1,19 +1,25 @@
 # frozen_string_literal: true
 
-# Initial :initiatives participatory space registration is already done on 'decidim-initiatives' gem initialization
-#
+# Note: Initial :initiatives participatory space registration is already done on 'decidim-initiatives' gem initialization
+
+
 # Define additional resource permissions for initiatives
 manifest = Decidim.find_resource_manifest(:initiatives_type)
 if manifest.present?
   manifest.actions = %w(create vote view_author_metadata)
 end
 
-#
-# Decidim.register_participatory_space(:initiatives) do |participatory_space|
-#   ...
-#   participatory_space.data_portable_entities = [
-#     "Decidim::Initiative",
-#     "Decidim::InitiativesVote"
-#   ]
-#   ...
-# end
+
+# Update the `.exports` section for :initiatives participatory space to include initiatives into open data
+manifest = Decidim.find_participatory_space_manifest(:initiatives)
+if manifest.present? && manifest.export_manifests.present?
+  export_manifest = manifest.export_manifests.find {|m| m.name == :initiatives}
+
+  if export_manifest.present? && !export_manifest.include_in_open_data
+    export_manifest.collection do |initiative|
+      Decidim::Initiative.where(id: initiative.id)
+    end
+
+    export_manifest.include_in_open_data = true
+  end
+end


### PR DESCRIPTION
Initially the open data exporter supported only Component type data to be included in open data export (for example Meetings, Comments, Proposals, etc).
The v0.24 introduced the first participatory space to be included into open data - Votings, the PR could be found here: https://github.com/decidim/decidim/pull/7388
After, there was additional enhancement in open data exporter to improve RAM usage and performance: https://github.com/decidim/decidim/pull/8593

This PR brings both open data exporter improvements to v0.22. In our case the Initiatives is the first participatory space that is included in open data.
The `initiatives/participatory_space.rb` contains "tricks" to updates the existing configuration (registration) of the participatory space in Decidim, because it has already been initialized earlier in the process of gem initialization.