### PR TITLE
BOSA21Q1-861 OpenDataJob performance issue

### DIFF
--- a/lib/extends/decidim-core/app/services/decidim/open_data_exporter.rb
+++ b/lib/extends/decidim-core/app/services/decidim/open_data_exporter.rb
@@ -29,7 +29,7 @@ module OpenDataExporterExtend
         components.where(manifest_name: export_manifest.manifest.name).find_each do |component|
           export_manifest.collection.call(component).find_in_batches(batch_size: 100) do |batch|
             exporter = Decidim::Exporters::CSV.new(batch, export_manifest.serializer)
-            headers.push(*exporter.headers)
+            headers.push(*exporter.send(:headers))
             exported = exporter.export
 
             tmpfile = Tempfile.new("#{export_manifest.name}-#{component.id}-")
@@ -56,9 +56,11 @@ module OpenDataExporterExtend
     end
 
     def data_for_participatory_space(export_manifest)
-      collection = participatory_spaces.filter { |space| space.manifest.name == export_manifest.manifest.name }.flat_map do |participatory_space|
-        export_manifest.collection.call(participatory_space)
-      end
+      # collection = participatory_spaces.filter { |space| space.manifest.name == export_manifest.manifest.name }.flat_map do |participatory_space|
+      #   export_manifest.collection.call(participatory_space)
+      # end
+      ids = participatory_spaces.filter { |space| space.manifest.name == export_manifest.manifest.name }.flat_map.map(&:id)
+      collection = export_manifest.collection.call(ids)
 
       Decidim::Exporters::CSV.new(collection, export_manifest.serializer).export
     end

--- a/lib/extends/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/lib/extends/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -16,8 +16,19 @@ if manifest.present? && manifest.export_manifests.present?
   export_manifest = manifest.export_manifests.find {|m| m.name == :initiatives}
 
   if export_manifest.present? && !export_manifest.include_in_open_data
-    export_manifest.collection do |initiative|
-      Decidim::Initiative.where(id: initiative.id)
+    # export_manifest.collection do |initiative|
+    #   Decidim::Initiative.where(id: initiative.id)
+    # end
+    export_manifest.collection do |initiative_ids|
+      Decidim::Initiative.where(id: initiative_ids).includes(
+        :author,
+        :attachment_collections,
+        :attachments,
+        :components,
+        :organization,
+        :votes,
+        scoped_type: :type
+      )
     end
 
     export_manifest.include_in_open_data = true


### PR DESCRIPTION
After "BOSA21Q1-853 Add initiatives into open data export." https://github.com/belighted/bosa/pull/233 the open data export became slower.
To enhance the performance here is a change of how the collection is defined by manifest and handled by exporter.

It is BOSA-specific (not a "PR to decidim" candidate) as default initiatives exporter provided by decidim doesn't include additional data to put into export (see here for extended serializer: https://github.com/belighted/bosa/blob/master/lib/extends/decidim-initiatives/app/serializers/decidim/initiatives/initiative_serializer.rb#L18-L55).